### PR TITLE
Cache: Implemented expiring LRU caching, disabled by default

### DIFF
--- a/algoliasearch/src/main/java/com/algolia/search/saas/BaseAPIClient.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/BaseAPIClient.java
@@ -62,6 +62,8 @@ abstract class BaseAPIClient {
     private String tagFilters;
     private String userToken;
     private HashMap<String, String> headers;
+    private ExpiringCache<String, String> cache;
+    private boolean isCacheEnabled = false;
 
     /**
      * Algolia Search initialization
@@ -94,6 +96,48 @@ abstract class BaseAPIClient {
             readHostsArray = writeHostsArray = hostsArray;
         }
         headers = new HashMap<String, String>();
+    }
+
+    /**
+     * Enables search cache with default parameters
+     */
+    public void enableSearchCache() {
+        isCacheEnabled = true;
+        if (cache == null) {
+            cache = new ExpiringCache<>();
+        }
+    }
+
+
+    /**
+     * Enables search cache with default parameters
+     *
+     * @param timeoutInSeconds duration during wich an request is kept in cache
+     * @param maxRequests maximum amount of requests to keep before removing the least recently used
+     */
+    public void enableSearchCache(int timeoutInSeconds, int maxRequests) {
+        isCacheEnabled = true;
+        cache = new ExpiringCache<>(timeoutInSeconds, maxRequests);
+    }
+
+    /**
+     * Disable and reset cache
+     */
+    public void disableSearchCache() {
+        isCacheEnabled = false;
+        if (cache != null) {
+            cache.reset();
+            cache = null;
+        }
+    }
+
+    /**
+     * Remove all entries from cache
+     */
+    public void clearSearchCache() {
+        if (cache != null) {
+            cache.reset();
+        }
     }
 
     /**
@@ -351,6 +395,7 @@ abstract class BaseAPIClient {
 
     /**
      * Reads the InputStream into a byte array
+     *
      * @param stream the InputStream to read
      * @return the stream's content as a byte[]
      * @throws AlgoliaException if the stream can't be read or flushed
@@ -377,10 +422,6 @@ abstract class BaseAPIClient {
         return new JSONObject(new JSONTokener(input));
     }
 
-    private JSONObject _getJSONObject(byte[] array) throws JSONException, UnsupportedEncodingException {
-        return new JSONObject(new String(array, "UTF-8"));
-    }
-
     private JSONObject _getAnswerJSONObject(InputStream istream) throws IOException, JSONException {
         return _getJSONObject(_toCharArray(istream));
     }
@@ -398,8 +439,21 @@ abstract class BaseAPIClient {
      * @throws AlgoliaException if the request data is not valid json
      */
     private synchronized JSONObject _request(Method m, String url, String json, List<String> hostsArray, int connectTimeout, int readTimeout) throws AlgoliaException {
+        String cacheKey = null;
+        String jsonStr = null;
+        if (isCacheEnabled) {
+            cacheKey = String.format("%s:%s(%s)", m, url, json);
+            jsonStr = cache.get(cacheKey);
+        }
         try {
-            return _getJSONObject(_requestRaw(m, url, json, hostsArray, connectTimeout, readTimeout));
+            if (jsonStr == null) {
+                final byte[] requestRaw = _requestRaw(m, url, json, hostsArray, connectTimeout, readTimeout);
+                jsonStr = new String(requestRaw, "UTF-8");
+                if (isCacheEnabled) {
+                    cache.put(cacheKey, jsonStr);
+                }
+            }
+            return new JSONObject(jsonStr);
         } catch (JSONException e) {
             throw new AlgoliaException("JSON decode error:" + e.getMessage());
         } catch (UnsupportedEncodingException e) {
@@ -444,7 +498,7 @@ abstract class BaseAPIClient {
             // set URL
             URL hostURL;
             HttpURLConnection hostConnection;
-            try{
+            try {
                 hostURL = new URL("https://" + host + url);
                 hostConnection = (HttpURLConnection) hostURL.openConnection();
                 hostConnection.setRequestMethod(requestMethod);
@@ -537,8 +591,7 @@ abstract class BaseAPIClient {
                 String encoding = hostConnection.getContentEncoding();
                 if (encoding != null && encoding.contains("gzip")) {
                     return _toByteArray(new GZIPInputStream(stream));
-                }
-                else {
+                } else {
                     return _toByteArray(stream);
                 }
             } catch (IOException e) {

--- a/algoliasearch/src/main/java/com/algolia/search/saas/ExpiringCache.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/ExpiringCache.java
@@ -1,0 +1,77 @@
+package com.algolia.search.saas;
+
+import android.util.LruCache;
+import android.util.Pair;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A cache that holds strong references to a limited number of values for a limited time.
+ */
+public class ExpiringCache<K, V> {
+    public static final TimeUnit expirationTimeUnit = TimeUnit.SECONDS;
+    public static final int defaultExpirationTimeout = 2;
+    public static final int defaultMaxSize = 64;
+    public final int expirationTimeout; // Time after which a cache entry is invalidated
+
+    private final LruCache<K, Pair<V, Long>> lruCache;
+
+    public ExpiringCache(final int timeout, final int maxSize) {
+        lruCache = new LruCache<>(maxSize);
+        expirationTimeout = timeout;
+    }
+
+    public ExpiringCache() {
+        this(defaultExpirationTimeout, defaultMaxSize);
+    }
+
+
+    /**
+     * Puts a value in the cache, computing an expiration time
+     *
+     * @return the previous value for this key, if any
+     */
+    public V put(K key, V value) {
+        V previous = null;
+
+        synchronized (this) {
+            long timeout = System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(expirationTimeout, expirationTimeUnit);
+            final Pair<V, Long> previousPair = lruCache.put(key, new Pair<>(value, timeout));
+            if (previousPair != null) {
+                previous = previousPair.first;
+            }
+        }
+        return previous;
+    }
+
+    /**
+     * Get a value from the cache
+     *
+     * @return the cached value if it is still valid
+     */
+    synchronized public V get(K key) {
+        final Pair<V, Long> cachePair = lruCache.get(key);
+        if (cachePair != null && cachePair.first != null) {
+            if (cachePair.second > System.currentTimeMillis()) {
+                return cachePair.first;
+            } else {
+                lruCache.remove(key);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @return the number of entries in the cache.
+     */
+    public int size() {
+        return lruCache.size();
+    }
+
+    /**
+     * Reset the cache, keeping the current settings.
+     */
+    public void reset() {
+        lruCache.evictAll();
+    }
+}


### PR DESCRIPTION
The cache can be enabled as such:

- `apiClient.enableCache()` caches results for 120 seconds up to a maximum of 64 requests
- `apiClient.enableCache(X, Y)` caches results for X seconds up to a maximum of Y requests 
