### PR TITLE
gradle: Specified properties to speed-up build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,15 @@
+# Use gradle deamon to fasten successive builds
+org.gradle.deamon = true
+
+# Parallelize project build, if possible
+org.gradle.parallel=true
+
+# Configure only relevant projects for each build
+org.gradle.configureondemand=true
+
+# JVM arguments:
+# -set maximum heap size to 2048m
+# -set maximum size of permanent space to 5120m
+# -generate a heap dump when unable to allocate
+# -display characters as UTF8
+org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8


### PR DESCRIPTION
Before:

> Running 20 times `./gradlew clean build`...
> Average run time: **11.30 secs**; standard deviation: **1.33 secs**

----

After:

> Running 20 times `./gradlew clean build`...
> Average run time: **8.11 secs**; standard deviation: **0.78 secs**

Build is now **28%** faster.