### PR TITLE
Tests: Retrying on failure to avoid "Unable to resolve host"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
 - adb shell input keyevent 82 &
 script:
 - set -o pipefail
-- bash run_test.sh
+- travis_retry bash run_test.sh
 env:
   global:
     - secure: DENCjlvzW54U9QH7mWO3LJVLYEiX0Mj9U44QoGQcienflSDlVN1UhAiT7xnCKwWT38B37CzeQlHc541z78vAj+YPzPbebowFW0aiq/LNdFMigsT1j3gLpqrICjylG08i1Ho95FLCOaJSQWZJ5nSd3OceWLLxCYUXtS9E3BuMHGg=


### PR DESCRIPTION
Using `travis_retry` to avoid intermittent network issues, as advised by Travis in their [blogpost about network build errors](https://blog.travis-ci.com/2013-05-20-network-timeouts-build-retries/).

If those errors happen regularly, it is probably worth reaching out to Travis team to see if they have a better solution.