### PR TITLE
Build on multiple Android versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,40 @@
+sudo: false # Explicitely choose container-based infrastructure, see https://docs.travis-ci.com/user/ci-environment/
 language: android
+jdk:
+  - oraclejdk7
+env:
+  global:
+    - secure: DENCjlvzW54U9QH7mWO3LJVLYEiX0Mj9U44QoGQcienflSDlVN1UhAiT7xnCKwWT38B37CzeQlHc541z78vAj+YPzPbebowFW0aiq/LNdFMigsT1j3gLpqrICjylG08i1Ho95FLCOaJSQWZJ5nSd3OceWLLxCYUXtS9E3BuMHGg=
+    - secure: HBdvSvplPEJWEu7aij7cA+ZiQt2qmb9+Q8WsUGOJJ1uYIOt/MVHSo0bYYLfk90eFlnJecN+oBi92LCM9PUT3mKIHm9apRsK9os+W/6wIezD+rKVYPfOLZ4uINaFRDjXUJqKB46fzVR54vc4N2QO0+spn7Sv7sXaytYEPwrO6tmo=
+    - ANDROID_ABI=armeabi-v7a
+  matrix:
+    - ANDROID_TARGET=android-15
+    - ANDROID_TARGET=android-16
+    - ANDROID_TARGET=android-19
+    - ANDROID_TARGET=android-21
+    - ANDROID_TARGET=android-22 # Travis does not yet support android-23
+matrix:
+  fast_finish: true
 android:
   components:
-    - build-tools-21.1.2
+    - build-tools-23.0.1
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/daemon
+    - $HOME/.gradle/native
+    - $HOME/.gradle/wrapper
 before_script:
-- echo no | android create avd --force -n test -t android-21 --abi armeabi-v7a
+# Avoid useless reupload of cache after every build, see https://docs.travis-ci.com/user/languages/android
+- rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+# Update Android SDK, accepting all licences with expect
+- bash update_sdk.sh
+# Create Android Virtual Device with current config, saying no to custom build
+- echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI
+# Run emulator and wait until it is ready, then send KEYCODE_MENU to unlock the phone
 - emulator -avd test -no-skin -no-audio -no-window &
 - android-wait-for-emulator
 - adb shell input keyevent 82 &
 script:
 - set -o pipefail
 - travis_retry bash run_test.sh
-env:
-  global:
-    - secure: DENCjlvzW54U9QH7mWO3LJVLYEiX0Mj9U44QoGQcienflSDlVN1UhAiT7xnCKwWT38B37CzeQlHc541z78vAj+YPzPbebowFW0aiq/LNdFMigsT1j3gLpqrICjylG08i1Ho95FLCOaJSQWZJ5nSd3OceWLLxCYUXtS9E3BuMHGg=
-    - secure: HBdvSvplPEJWEu7aij7cA+ZiQt2qmb9+Q8WsUGOJJ1uYIOt/MVHSo0bYYLfk90eFlnJecN+oBi92LCM9PUT3mKIHm9apRsK9os+W/6wIezD+rKVYPfOLZ4uINaFRDjXUJqKB46fzVR54vc4N2QO0+spn7Sv7sXaytYEPwrO6tmo=

--- a/update_sdk.sh
+++ b/update_sdk.sh
@@ -1,0 +1,16 @@
+#! /bin/sh
+if ! [[ $ANDROID_TARGET && $ANDROID_ABI ]]; then
+    echo "Error: Android Target and ABI should be set."
+    echo "Target: $ANDROID_TARGET"
+    echo "ABI: $ANDROID_ABI"
+    exit 1
+else
+    expect -c "
+set timeout -1;
+spawn android update sdk --no-ui --all --filter platform-tools,extra-android-support,$ANDROID_TARGET,sys-img-$ANDROID_ABI-$ANDROID_TARGET,sysimg${ANDROID_TARGET/android/};
+expect {
+		    \"Do you accept the license\" { exp_send \"y\r\" ; exp_continue }
+		        eof
+}
+"
+fi


### PR DESCRIPTION
Updates to our travis config to run parallel builds on different android versions, addressing #26.

- Build Matrix: builds at the same time on the five most frequent android versions
- Travis Cache: stores Gradle caches in Travis to avoid starting from scratch on each build