### PR TITLE
Index: Disabling distinct on deleteByQuery methods, fixes #13

### DIFF
--- a/algoliasearch/src/main/java/com/algolia/search/saas/BaseIndex.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/BaseIndex.java
@@ -310,6 +310,7 @@ abstract class BaseIndex {
     protected void deleteByQuery(Query query) throws AlgoliaException {
         query.setAttributesToRetrieve("objectID");
         query.setHitsPerPage(100);
+        query.enableDistinct(false);
 
         JSONObject results = this.search(query);
         try {

--- a/algoliasearch/src/main/java/com/algolia/search/saas/Index.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/Index.java
@@ -424,6 +424,7 @@ public class Index extends BaseIndex {
      * @param listener the listener that will receive the result or error.
      */
     public void deleteByQueryASync(Query query, DeleteObjectsListener listener) {
+        query.enableDistinct(false);
         TaskParams.DeleteObjects params = new TaskParams.DeleteObjects(listener, IndexMethod.DeleteByQuery, query);
         new AsyncDeleteTask().execute(params);
     }


### PR DESCRIPTION
See #13, `deleteByQuery` methods triggered Exceptions when called on an index with distinct > 1.

Fixed by disabling `distinct` at query time, although once we'll have #18 we should refactor it with `browse` as [in the Java client](https://github.com/algolia/algoliasearch-client-java/blob/master/src/main/java/com/algolia/search/saas/Index.java#L391).