### PR TITLE
App: MinSDKVersion lowered to 7

### DIFF
--- a/algoliasearch/build.gradle
+++ b/algoliasearch/build.gradle
@@ -33,7 +33,7 @@ android {
     compileSdkVersion 21
     buildToolsVersion '21.1.2'
     defaultConfig {
-        minSdkVersion 14
+        minSdkVersion 7
         targetSdkVersion 21
         versionCode 1
         versionName PUBLISH_VERSION

--- a/algoliasearch/src/main/java/com/algolia/search/saas/ExpiringCache.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/ExpiringCache.java
@@ -1,6 +1,6 @@
 package com.algolia.search.saas;
 
-import android.util.LruCache;
+import android.support.v4.util.LruCache;
 import android.util.Pair;
 
 import java.util.concurrent.TimeUnit;


### PR DESCRIPTION
Reduced `minSdkVersion` to the lowest version we can accept (we can't get under 7 without dropping AppCompat).