### PR TITLE
Tests: Specified unitTest Helper file in scripts

### DIFF
--- a/setup_tests.sh
+++ b/setup_tests.sh
@@ -5,7 +5,7 @@ set -o pipefail
 
 if [ -z "$FILE" ]; 
 then 
-    FILE="algoliasearch/src/androidTest/java/com/algolia/search/saas/Helpers.java"
+    FILE="algoliasearch/src/test/java/com/algolia/search/saas/Helpers.java"
 fi
 echo "Helper file: $FILE."
 cp $FILE $FILE.bak

--- a/teardown_tests.sh
+++ b/teardown_tests.sh
@@ -3,6 +3,11 @@
 set -e
 set -o pipefail
 
+if [ -z "$FILE" ]; 
+then 
+    FILE="algoliasearch/src/test/java/com/algolia/search/saas/Helpers.java"
+fi
+
 echo "Restoring Helper file..."
 mv $FILE.bak $FILE
 rm $FILE.tmp


### PR DESCRIPTION
Fixed a forgotten reference to androidTest, allowing again `./setup_tests.sh` and `./teardown_tests.sh` to manually setup and teardown `Helper.java` when running tests locally.