### PR TITLE
Fix "Could not find method nexusStaging()"

### DIFF
--- a/algoliasearch/build.gradle
+++ b/algoliasearch/build.gradle
@@ -24,19 +24,9 @@
 apply plugin: 'com.android.library'
 
 ext {
-    PUBLISH_GROUP_ID = 'com.algolia'
+    PUBLISH_GROUP_ID = rootProject.properties["PUBLISH_GROUP_ID"] ?: ""
     PUBLISH_ARTIFACT_ID = 'algoliasearch-android'
     PUBLISH_VERSION = '2.7.0'
-    PUBLISH_STAGING_ID = 'f6edc053ff9131'
-    /* To get the staging id, you can either:
-    - Use the 'getStagingProfile' task added by the 'io.codearte.nexus-staging' plugin
-    - Log-in on sonatype.org, go to staging profile, select com.algolia, id = last part of URL */
-}
-
-
-nexusStaging {
-    packageGroup = PUBLISH_GROUP_ID
-    stagingProfileId = PUBLISH_STAGING_ID
 }
 
 android {

--- a/build.gradle
+++ b/build.gradle
@@ -42,4 +42,17 @@ allprojects {
     }
 }
 
+ext {
+    PUBLISH_GROUP_ID = 'com.algolia'
+}
+
+
 apply plugin: 'io.codearte.nexus-staging'
+
+nexusStaging {
+    packageGroup = PUBLISH_GROUP_ID
+    stagingProfileId = 'f6edc053ff9131'
+    /* To get the staging id, you can either:
+    - Use the 'getStagingProfile' task added by the 'io.codearte.nexus-staging' plugin
+    - Log-in on sonatype.org, go to staging profile, select com.algolia, id = last part of URL */
+}


### PR DESCRIPTION
This fixes a build error introduced by the recommended way to configure nexusStaging. 
See Codearte/gradle-nexus-staging-plugin#16 if you want more details.
