### PR TITLE
Cache: per-index expiring LRU search cache, disabled by default

### DIFF
--- a/algoliasearch/src/main/java/com/algolia/search/saas/BaseAPIClient.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/BaseAPIClient.java
@@ -336,7 +336,7 @@ abstract class BaseAPIClient {
      * @return the stream's content as a String
      * @throws IOException if the stream can't be read, decoded as UTF-8 or closed
      */
-    private String _toCharArray(InputStream stream) throws IOException {
+    private static String _toCharArray(InputStream stream) throws IOException {
         InputStreamReader is = new InputStreamReader(stream, "UTF-8");
         StringBuilder builder = new StringBuilder();
         char[] buf = new char[1000];
@@ -373,15 +373,15 @@ abstract class BaseAPIClient {
     }
 
 
-    private JSONObject _getJSONObject(String input) throws JSONException {
+    protected static JSONObject _getJSONObject(String input) throws JSONException {
         return new JSONObject(new JSONTokener(input));
     }
 
-    private JSONObject _getJSONObject(byte[] array) throws JSONException, UnsupportedEncodingException {
+    protected static JSONObject _getJSONObject(byte[] array) throws JSONException, UnsupportedEncodingException {
         return new JSONObject(new String(array, "UTF-8"));
     }
 
-    private JSONObject _getAnswerJSONObject(InputStream istream) throws IOException, JSONException {
+    private static JSONObject _getAnswerJSONObject(InputStream istream) throws IOException, JSONException {
         return _getJSONObject(_toCharArray(istream));
     }
 

--- a/algoliasearch/src/main/java/com/algolia/search/saas/BaseIndex.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/BaseIndex.java
@@ -44,7 +44,7 @@ abstract class BaseIndex {
     private APIClient client;
     private String encodedIndexName;
     private String indexName;
-    private ExpiringCache<String, String> searchCache;
+    private ExpiringCache<String, byte[]> searchCache;
     private boolean isCacheEnabled = false;
 
     private final long MAX_TIME_MS_TO_WAIT = 10000L;
@@ -79,7 +79,7 @@ abstract class BaseIndex {
     /**
      * Add an object in this index
      *
-     * @param obj the object to add.
+     * @param obj      the object to add.
      * @param objectID an objectID you want to attribute to this object
      * (if the attribute already exist the old object will be overwrite)
      * @throws AlgoliaException
@@ -338,19 +338,19 @@ abstract class BaseIndex {
      */
     protected JSONObject search(@NonNull Query query) throws AlgoliaException {
         String cacheKey = null;
-        String jsonStr = null;
+        byte[] rawResponse = null;
         if (isCacheEnabled) {
             cacheKey = String.format("%s", query.getQueryString());
-            jsonStr = searchCache.get(cacheKey);
+            rawResponse = searchCache.get(cacheKey);
         }
         try {
-            if (jsonStr == null) {
-                jsonStr = new String(searchRaw(query), "UTF-8");
+            if (rawResponse == null) {
+                rawResponse = searchRaw(query);
                 if (isCacheEnabled) {
-                    searchCache.put(cacheKey, jsonStr);
+                    searchCache.put(cacheKey, rawResponse);
                 }
             }
-            return BaseAPIClient._getJSONObject(jsonStr);
+            return BaseAPIClient._getJSONObject(rawResponse);
         } catch (UnsupportedEncodingException | JSONException e) {
             throw new AlgoliaException(e.getMessage());
         }

--- a/algoliasearch/src/main/java/com/algolia/search/saas/BaseIndex.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/BaseIndex.java
@@ -23,6 +23,8 @@
 
 package com.algolia.search.saas;
 
+import android.support.annotation.NonNull;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -42,6 +44,9 @@ abstract class BaseIndex {
     private APIClient client;
     private String encodedIndexName;
     private String indexName;
+    private ExpiringCache<String, String> searchCache;
+    private boolean isCacheEnabled = false;
+
     private final long MAX_TIME_MS_TO_WAIT = 10000L;
 
     /**
@@ -112,8 +117,7 @@ abstract class BaseIndex {
     protected JSONObject addObjects(JSONArray inputArray) throws AlgoliaException {
         try {
             JSONArray array = new JSONArray();
-            for(int n = 0; n < inputArray.length(); n++)
-            {
+            for (int n = 0; n < inputArray.length(); n++) {
                 JSONObject action = new JSONObject();
                 action.put("action", "addObject");
                 action.put("body", inputArray.getJSONObject(n));
@@ -142,11 +146,11 @@ abstract class BaseIndex {
     /**
      * Get an object from this index
      *
-     * @param objectID the unique identifier of the object to retrieve
+     * @param objectID             the unique identifier of the object to retrieve
      * @param attributesToRetrieve contains the list of attributes to retrieve.
      * @throws AlgoliaException
      */
-    protected JSONObject getObject(String objectID,  List<String> attributesToRetrieve) throws AlgoliaException {
+    protected JSONObject getObject(String objectID, List<String> attributesToRetrieve) throws AlgoliaException {
         try {
             StringBuilder params = new StringBuilder();
             params.append("?attributes=");
@@ -180,7 +184,7 @@ abstract class BaseIndex {
             JSONObject body = new JSONObject();
             body.put("requests", requests);
             return client.postRequest("/1/indexes/*/objects", body.toString(), true);
-        } catch (JSONException e){
+        } catch (JSONException e) {
             throw new AlgoliaException(e.getMessage());
         }
     }
@@ -208,8 +212,7 @@ abstract class BaseIndex {
     protected JSONObject partialUpdateObjects(JSONArray inputArray) throws AlgoliaException {
         try {
             JSONArray array = new JSONArray();
-            for(int n = 0; n < inputArray.length(); n++)
-            {
+            for (int n = 0; n < inputArray.length(); n++) {
                 JSONObject obj = inputArray.getJSONObject(n);
                 JSONObject action = new JSONObject();
                 action.put("action", "partialUpdateObject");
@@ -246,8 +249,7 @@ abstract class BaseIndex {
     protected JSONObject saveObjects(JSONArray inputArray) throws AlgoliaException {
         try {
             JSONArray array = new JSONArray();
-            for(int n = 0; n < inputArray.length(); n++)
-            {
+            for (int n = 0; n < inputArray.length(); n++) {
                 JSONObject obj = inputArray.getJSONObject(n);
                 JSONObject action = new JSONObject();
                 action.put("action", "updateObject");
@@ -292,7 +294,7 @@ abstract class BaseIndex {
                 obj.put("objectID", id);
                 JSONObject action = new JSONObject();
                 action.put("action", "deleteObject");
-                action.put("body",obj);
+                action.put("body", obj);
                 array.put(action);
             }
             return batch(array);
@@ -330,24 +332,37 @@ abstract class BaseIndex {
 
     /**
      * Search inside the index
+     *
      * @return a JSONObject containing search results
      * @throws AlgoliaException
      */
-    protected JSONObject search(Query query) throws AlgoliaException {
-        String paramsString = query.getQueryString();
-        if (paramsString.length() > 0) {
-            return client.getRequest("/1/indexes/" + encodedIndexName + "?" + paramsString, true);
-        } else {
-            return client.getRequest("/1/indexes/" + encodedIndexName, true);
+    protected JSONObject search(@NonNull Query query) throws AlgoliaException {
+        String cacheKey = null;
+        String jsonStr = null;
+        if (isCacheEnabled) {
+            cacheKey = String.format("%s", query.getQueryString());
+            jsonStr = searchCache.get(cacheKey);
+        }
+        try {
+            if (jsonStr == null) {
+                jsonStr = new String(searchRaw(query), "UTF-8");
+                if (isCacheEnabled) {
+                    searchCache.put(cacheKey, jsonStr);
+                }
+            }
+            return BaseAPIClient._getJSONObject(jsonStr);
+        } catch (UnsupportedEncodingException | JSONException e) {
+            throw new AlgoliaException(e.getMessage());
         }
     }
 
     /**
      * Search inside the index
+     *
      * @return a byte array containing search results
      * @throws AlgoliaException
      */
-    protected byte[] searchRaw(Query query) throws AlgoliaException {
+    protected byte[] searchRaw(@NonNull Query query) throws AlgoliaException {
         String paramsString = query.getQueryString();
         if (paramsString.length() > 0) {
             return client.getRequestRaw("/1/indexes/" + encodedIndexName + "?" + paramsString, true);
@@ -360,7 +375,7 @@ abstract class BaseIndex {
      * Wait the publication of a task on the server.
      * All server task are asynchronous and you can check with this method that the task is published.
      *
-     * @param taskID the id of the task returned by server
+     * @param taskID     the id of the task returned by server
      * @param timeToWait time to sleep seed
      * @throws AlgoliaException
      */
@@ -559,4 +574,42 @@ abstract class BaseIndex {
     public JSONObject searchDisjunctiveFaceting(Query query, List<String> disjunctiveFacets) throws AlgoliaException {
         return searchDisjunctiveFaceting(query, disjunctiveFacets, null);
     }
+
+    /**
+     * Enable search cache with default parameters
+     */
+    public void enableSearchCache() {
+        enableSearchCache(ExpiringCache.defaultExpirationTimeout, ExpiringCache.defaultMaxSize);
+    }
+
+    /**
+     * Enable search cache with custom parameters
+     *
+     * @param timeoutInSeconds duration during which an request is kept in cache
+     * @param maxRequests      maximum amount of requests to keep before removing the least recently used
+     */
+    public void enableSearchCache(int timeoutInSeconds, int maxRequests) {
+        isCacheEnabled = true;
+        searchCache = new ExpiringCache<>(timeoutInSeconds, maxRequests);
+    }
+
+    /**
+     * Disable and reset cache
+     */
+    public void disableSearchCache() {
+        isCacheEnabled = false;
+        if (searchCache != null) {
+            searchCache.reset();
+        }
+    }
+
+    /**
+     * Remove all entries from cache
+     */
+    public void clearSearchCache() {
+        if (searchCache != null) {
+            searchCache.reset();
+        }
+    }
+
 }

--- a/algoliasearch/src/main/java/com/algolia/search/saas/ExpiringCache.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/ExpiringCache.java
@@ -1,0 +1,77 @@
+package com.algolia.search.saas;
+
+import android.support.v4.util.LruCache;
+import android.util.Pair;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A cache that holds strong references to a limited number of values for a limited time.
+ */
+class ExpiringCache<K, V> {
+    public static final TimeUnit expirationTimeUnit = TimeUnit.SECONDS;
+    public static final int defaultExpirationTimeout = 2;
+    public static final int defaultMaxSize = 64;
+    public final int expirationTimeout; // Time after which a cache entry is invalidated
+
+    private final LruCache<K, Pair<V, Long>> lruCache;
+
+    public ExpiringCache(final int timeout, final int maxSize) {
+        lruCache = new LruCache<>(maxSize);
+        expirationTimeout = timeout;
+    }
+
+    public ExpiringCache() {
+        this(defaultExpirationTimeout, defaultMaxSize);
+    }
+
+
+    /**
+     * Puts a value in the cache, computing an expiration time
+     *
+     * @return the previous value for this key, if any
+     */
+    public V put(K key, V value) {
+        V previous = null;
+
+        synchronized (this) {
+            long timeout = System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(expirationTimeout, expirationTimeUnit);
+            final Pair<V, Long> previousPair = lruCache.put(key, new Pair<>(value, timeout));
+            if (previousPair != null) {
+                previous = previousPair.first;
+            }
+        }
+        return previous;
+    }
+
+    /**
+     * Get a value from the cache
+     *
+     * @return the cached value if it is still valid, else null.
+     */
+    synchronized public V get(K key) {
+        final Pair<V, Long> cachePair = lruCache.get(key);
+        if (cachePair != null && cachePair.first != null) {
+            if (cachePair.second > System.currentTimeMillis()) {
+                return cachePair.first;
+            } else {
+                lruCache.remove(key);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @return the number of entries in the cache.
+     */
+    public int size() {
+        return lruCache.size();
+    }
+
+    /**
+     * Reset the cache, keeping the current settings.
+     */
+    public void reset() {
+        lruCache.evictAll();
+    }
+}

--- a/algoliasearch/src/test/java/com/algolia/search/saas/IndexTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/IndexTest.java
@@ -33,7 +33,6 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.mockito.internal.util.reflection.Whitebox;
-import org.powermock.core.classloader.annotations.PrepareForTest;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -42,10 +41,16 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * <a href="http://d.android.com/tools/testing/testing_android.html">Testing Fundamentals</a>
@@ -394,5 +399,59 @@ public class IndexTest extends PowerMockTestCase {
 
         // Expect correct certificate handling and successful search
         testSearchAsync();
+    }
+
+    @Test
+    public void testCacheUseIfEnabled() throws Exception {
+        index.enableSearchCache();
+        verifySearchTwiceCalls(1);
+    }
+
+    @Test
+    public void testCacheDontUseByDefault() throws Exception {
+        verifySearchTwiceCalls(2);
+    }
+
+    @Test
+    public void testCacheDontUseIfDisabled() throws Exception {
+        index.disableSearchCache();
+        verifySearchTwiceCalls(2);
+    }
+
+    @Test
+    public void testCacheTimeout() throws Exception {
+        index.enableSearchCache(1, ExpiringCache.defaultMaxSize);
+        verifySearchTwiceCalls(2, 2);
+    }
+
+    /**
+     * Verifies the number of requests fired by two successive search queries
+     *
+     * @param nbTimes expected amount of requests
+     */
+    private void verifySearchTwiceCalls(int nbTimes) throws Exception {
+        verifySearchTwiceCalls(nbTimes, 0);
+    }
+
+    /**
+     * Verifies the number of requests fired by two search queries
+     *
+     * @param nbTimes            expected amount of requests
+     * @param waitBetweenSeconds optional time to wait between the two queries
+     */
+    private void verifySearchTwiceCalls(int nbTimes, int waitBetweenSeconds) throws Exception {
+        // Given a index, using a client that returns some json on search
+        APIClient mockClient = mock(APIClient.class);
+        Whitebox.setInternalState(index, "client", mockClient);
+        when(mockClient.getRequestRaw(anyString(), anyBoolean())).thenReturn("{foo:42}".getBytes());
+
+        // When searching twice separated by waitBetweenSeconds, fires nbTimes requests
+        final Query query = new Query("San");
+        index.search(query);
+        if (waitBetweenSeconds > 0) {
+            Thread.sleep(waitBetweenSeconds * 1000);
+        }
+        index.search(query);
+        verify(mockClient, times(nbTimes)).getRequestRaw(anyString(), anyBoolean());
     }
 }


### PR DESCRIPTION
This addresses the issues of the previous implementation outlined in #50.