### PR TITLE
Allow extra query parameters to be specified

### DIFF
--- a/algoliasearch/src/androidTest/java/com/algolia/search/saas/ApplicationTest.java
+++ b/algoliasearch/src/androidTest/java/com/algolia/search/saas/ApplicationTest.java
@@ -87,6 +87,41 @@ public class ApplicationTest extends ApplicationTestCase<Application> {
     }
 
     @UiThreadTest
+    public void testQueryExtraParameters() throws Exception {
+        // Accessor methods.
+        {
+            Query query = new Query();
+            query.set("extra", "value");
+            assertEquals("value", query.get("extra"));
+            assertEquals("extra=value", query.getQueryString());
+            query.set("abc", "def");
+            String url = query.getQueryString();
+            assertTrue(url.equals("abc=def&extra=value") || url.equals("extra=value&abc=def"));
+        }
+        // Percent escaping.
+        {
+            Query query = new Query();
+            query.set("%&=", "àéïôù");
+            assertEquals("%25%26%3D=%C3%A0%C3%A9%C3%AF%C3%B4%C3%B9", query.getQueryString());
+        }
+        // Overriding a typed query parameter.
+        {
+            Query query = new Query();
+            query.hitsPerPage = 100;
+            query.set("hitsPerPage", "666");
+            assertEquals("hitsPerPage=100&hitsPerPage=666", query.getQueryString());
+        }
+        // Deleting a parameter.
+        {
+            Query query = new Query();
+            query.set("abc", "ABC");
+            query.set("def", "DEF");
+            query.set("abc", null);
+            assertEquals("def=DEF", query.getQueryString());
+        }
+    }
+
+    @UiThreadTest
     public void testSearchAsync() throws Exception {
         final CountDownLatch signal = new CountDownLatch(1);
 

--- a/algoliasearch/src/androidTest/java/com/algolia/search/saas/ApplicationTest.java
+++ b/algoliasearch/src/androidTest/java/com/algolia/search/saas/ApplicationTest.java
@@ -87,41 +87,6 @@ public class ApplicationTest extends ApplicationTestCase<Application> {
     }
 
     @UiThreadTest
-    public void testQueryExtraParameters() throws Exception {
-        // Accessor methods.
-        {
-            Query query = new Query();
-            query.set("extra", "value");
-            assertEquals("value", query.get("extra"));
-            assertEquals("extra=value", query.getQueryString());
-            query.set("abc", "def");
-            String url = query.getQueryString();
-            assertTrue(url.equals("abc=def&extra=value") || url.equals("extra=value&abc=def"));
-        }
-        // Percent escaping.
-        {
-            Query query = new Query();
-            query.set("%&=", "àéïôù");
-            assertEquals("%25%26%3D=%C3%A0%C3%A9%C3%AF%C3%B4%C3%B9", query.getQueryString());
-        }
-        // Overriding a typed query parameter.
-        {
-            Query query = new Query();
-            query.hitsPerPage = 100;
-            query.set("hitsPerPage", "666");
-            assertEquals("hitsPerPage=100&hitsPerPage=666", query.getQueryString());
-        }
-        // Deleting a parameter.
-        {
-            Query query = new Query();
-            query.set("abc", "ABC");
-            query.set("def", "DEF");
-            query.set("abc", null);
-            assertEquals("def=DEF", query.getQueryString());
-        }
-    }
-
-    @UiThreadTest
     public void testSearchAsync() throws Exception {
         final CountDownLatch signal = new CountDownLatch(1);
 

--- a/algoliasearch/src/main/java/com/algolia/search/saas/Query.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/Query.java
@@ -1,5 +1,6 @@
 package com.algolia.search.saas;
 
+import android.support.annotation.NonNull;
 import android.util.Pair;
 
 import org.json.JSONArray;
@@ -8,7 +9,9 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /*
  * Copyright (c) 2015 Algolia
@@ -81,6 +84,7 @@ public class Query {
         TYPO_NOTSET
     }
 
+    protected Map<String, String> parameters = new HashMap<>();
     protected List<String> attributes;
     protected List<String> attributesToHighlight;
     protected List<String> attributesToSnippet;
@@ -1174,6 +1178,14 @@ public class Query {
                     stringBuilder.append("queryType=prefixNone");
                     break;
             }
+            // WARNING: Any extra parameter will override any previous one with the same name.
+            for (Map.Entry<String, String> entry : parameters.entrySet()) {
+                if (stringBuilder.length() > 0)
+                    stringBuilder.append('&');
+                stringBuilder.append(URLEncoder.encode(entry.getKey(), "UTF-8"));
+                stringBuilder.append('=');
+                stringBuilder.append(URLEncoder.encode(entry.getValue(), "UTF-8"));
+            }
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }
@@ -1400,5 +1412,35 @@ public class Query {
      */
     public TypoTolerance getTypoTolerance() {
         return typoTolerance;
+    }
+
+    // ----------------------------------------------------------------------
+    // Low-level (untyped) accessors
+    // ----------------------------------------------------------------------
+
+    /**
+     * Set a parameter in an untyped fashion.
+     * This low-level accessor is intended to access parameters that this client does not yet support.
+     * @param name The parameter's name.
+     * @param value The parameter's value, or null to remove it.
+     *              It will first be converted to a String by the `toString()` method.
+     */
+    public @NonNull
+    Query set(@NonNull String name, Object value) {
+        if (value == null) {
+            parameters.remove(name);
+        } else {
+            parameters.put(name, value.toString());
+        }
+        return this;
+    }
+
+    /**
+     * Get a parameter in an untyped fashion.
+     * @param name The parameter's name.
+     * @return The parameter's value, or null if a parameter with the specified name does not exist.
+     */
+    public String get(@NonNull String name) {
+        return parameters.get(name);
     }
 }

--- a/algoliasearch/src/test/java/com/algolia/search/saas/QueryTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/QueryTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2015 Algolia
+ * http://www.algolia.com/
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.algolia.search.saas;
+
+import org.junit.Test;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+
+public class QueryTest extends PowerMockTestCase {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+    }
+
+    @Test
+    public void testQueryExtraParameters() throws Exception {
+        // Accessor methods.
+        {
+            Query query = new Query();
+            query.set("extra", "value");
+            assertEquals("value", query.get("extra"));
+            assertEquals("extra=value", query.getQueryString());
+            query.set("abc", "def");
+            String url = query.getQueryString();
+            assertTrue(url.equals("abc=def&extra=value") || url.equals("extra=value&abc=def"));
+        }
+        // Percent escaping.
+        {
+            Query query = new Query();
+            query.set("%&=", "àéïôù");
+            assertEquals("%25%26%3D=%C3%A0%C3%A9%C3%AF%C3%B4%C3%B9", query.getQueryString());
+        }
+        // Overriding a typed query parameter.
+        {
+            Query query = new Query();
+            query.hitsPerPage = 100;
+            query.set("hitsPerPage", "666");
+            assertEquals("hitsPerPage=100&hitsPerPage=666", query.getQueryString());
+        }
+        // Deleting a parameter.
+        {
+            Query query = new Query();
+            query.set("abc", "ABC");
+            query.set("def", "DEF");
+            query.set("abc", null);
+            assertEquals("def=DEF", query.getQueryString());
+        }
+    }
+}


### PR DESCRIPTION
The `Query` class now provides untyped accessors to a dictionary of extra parameters. Those parameters are appended to the query string after all the typed parameters. This allows using query parameters not supported by the current version of the API client.

Fixes #66.