### PR TITLE
Travis: Narrower retry use (only on gradle task)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,4 +39,4 @@ before_script:
 - adb shell input keyevent 82 &
 script:
 - set -o pipefail
-- travis_retry bash run_test.sh
+- bash run_test.sh

--- a/run_test.sh
+++ b/run_test.sh
@@ -6,6 +6,10 @@ set -o pipefail
 FILE=algoliasearch/src/test/java/com/algolia/search/saas/Helpers.java
 export FILE
 
+if [ "$TRAVIS" = "true" ]; then
+    RETRY="travis_retry" # If on travis, use travis_retry
+fi
+
 if ! [[ $TRAVIS_JOB_NUMBER && ${TRAVIS_JOB_NUMBER-_} ]]; then
     echo "/!\ TRAVIS_JOB_NUMBER is not set."
     TRAVIS_JOB_NUMBER=$RANDOM.$RANDOM
@@ -13,5 +17,5 @@ fi
 
 echo "Running Android test..."
 ./setup_tests.sh
-./gradlew testOnlineRelease
+$RETRY ./gradlew testOnlineRelease
 ./teardown_tests.sh


### PR DESCRIPTION
Using `travis_retry` only on `gradle` call to avoid unnecessary repeated setup/teardown.