### PR TITLE
Unify properties names

### DIFF
--- a/algoliasearch/android-release-jar.gradle
+++ b/algoliasearch/android-release-jar.gradle
@@ -98,7 +98,7 @@ uploadArchives {
                 }
             }
         }
-        
+
         pom.withXml {
             asNode().dependencies.dependency.findAll { xmlDep ->
                 // mark optional dependencies
@@ -113,12 +113,12 @@ uploadArchives {
                 }
             }
         }
-        
+
         // Add other pom properties here if you want (developer details / licenses)
         repository(url: "file://${localReleaseDest}")
 
         repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-            authentication(userName: project.hasProperty('ossrhUsername') ? project['ossrhUsername'] : 'FIXME', password: project.hasProperty('ossrhPassword') ? project['ossrhPassword'] : 'FIXME')
+            authentication(userName: project.hasProperty('nexusUsername') ? project['nexusUsername'] : 'FIXME', password: project.hasProperty('nexusPassword') ? project['nexusPassword'] : 'FIXME')
         }
     }
 }

--- a/run_test.sh
+++ b/run_test.sh
@@ -6,8 +6,35 @@ set -o pipefail
 FILE=algoliasearch/src/test/java/com/algolia/search/saas/Helpers.java
 export FILE
 
-if [ "$TRAVIS" = "true" ]; then
-    RETRY="travis_retry" # If on travis, use travis_retry
+my_travis_retry() {
+    local result=0
+    local count=1
+    while [ $count -le 3 ]; do
+        [ $result -ne 0 ] && {
+            echo -e "\n${ANSI_RED}The command \"$@\" failed. Retrying, $count of 3.${ANSI_RESET}\n" >&2
+        }
+        "$@"
+        result=$?
+        [ $result -eq 0 ] && break
+        count=$(($count + 1))
+        sleep 1
+    done
+    [ $count -gt 3 ] && {
+        echo -e "\n${ANSI_RED}The command \"$@\" failed 3 times.${ANSI_RESET}\n" >&2
+        }
+    return $result
+}
+
+if [ "$TRAVIS" = "true" ]; then # If on travis, use travis_retry
+    if [ -n "$(type -t travis_retry)" ] && [ "$(type -t travis_retry)" = function ]; then
+        RETRY="travis_retry" 
+    else
+        # travis_retry is undefined in subshells. the recommended way to handle this
+        # is to "include the function code directly", see following conversation
+        # Conversation:  https://twitter.com/plexus/status/499194992632811520
+        # Source: https://git.io/vV5md
+        RETRY="my_travis_retry"
+    fi
 fi
 
 if ! [[ $TRAVIS_JOB_NUMBER && ${TRAVIS_JOB_NUMBER-_} ]]; then


### PR DESCRIPTION
Changed gradle release script to use `nexus{Username,Password}` instead of `ossrh[...]`, which is the naming used in [gradle-nexus-staging-plugin](/Codearte/gradle-nexus-staging-plugin) and [gradle-nexus-plugin](/bmuschko/gradle-nexus-plugin). 
This simplifies `local.properties` by avoiding repeated values for different property names.

PS: Please ignore the change to `run_test.sh`: babf6b6 was cherry-picked to fix travis build, and is already in [v3](v3).