### PR TITLE
Client: Fixed stream being read when null

### DIFF
--- a/algoliasearch/src/main/java/com/algolia/search/saas/BaseAPIClient.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/BaseAPIClient.java
@@ -514,7 +514,11 @@ abstract class BaseAPIClient {
             } else if (code / 100 == 4) {
                 String message = "Error detected in backend";
                 try {
-                    message = _getAnswerJSONObject(stream).getString("message");
+                    if (stream == null) {
+                        message = "InputStream is null: No connection/error while connecting/no error data";
+                    } else {
+                        message = _getAnswerJSONObject(stream).getString("message");
+                    }
                 } catch (IOException e) {
                     addError(errors, host, e);
                     continue;
@@ -525,7 +529,13 @@ abstract class BaseAPIClient {
                 throw new AlgoliaException(message);
             } else {
                 try {
-                    errors.put(host, _toCharArray(stream));
+                    final String errorMessage;
+                    if (stream == null) {
+                        errorMessage = "InputStream is null: No connection/error while connecting/no error data";
+                    } else {
+                        errorMessage = _toCharArray(stream);
+                    }
+                    errors.put(host, errorMessage);
                 } catch (IOException e) {
                     errors.put(host, String.valueOf(code));
                 }


### PR DESCRIPTION
Fixed NPE due to the creation of an `InputStreamReader` directly on `getErrorStream()`, which [can return null](http://download.java.net/jdk7/archive/b123/docs/api/java/net/HttpURLConnection.html#getErrorStream%28%29).