### PR TITLE
Add missing query parameters `filters` and `numericFilters`

### DIFF
--- a/algoliasearch/src/main/java/com/algolia/search/saas/Query.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/Query.java
@@ -419,7 +419,15 @@ public class Query {
         return null;
     }
 
-    // NOTE: `filters` left out because type too complex.
+    private static final String KEY_FILTERS = "filters";
+
+    public @NonNull Query setFilters(String filters) {
+        return set(KEY_FILTERS, filters);
+    }
+
+    public String getFilters() {
+        return get(KEY_FILTERS);
+    }
 
     private static final String KEY_GET_RANKING_INFO = "getRankingInfo";
 
@@ -688,7 +696,24 @@ public class Query {
         return parseInt(get(KEY_MIN_WORD_SIZE_FOR_2_TYPOS));
     }
 
-    // NOTE: `numericFilters` left out because type too complex.
+    private static final String KEY_NUMERIC_FILTERS = "numericFilters";
+
+    public @NonNull Query setNumericFilters(JSONArray filters) {
+        return set(KEY_NUMERIC_FILTERS, filters);
+    }
+
+    public JSONArray getNumericFilters() {
+        try {
+            String value = get(KEY_NUMERIC_FILTERS);
+            if (value != null) {
+                return new JSONArray(value);
+            }
+        }
+        catch (JSONException e) {
+            // Will return null
+        }
+        return null;
+    }
 
     private static final String KEY_OPTIONAL_WORDS = "optionalWords";
 

--- a/algoliasearch/src/test/java/com/algolia/search/saas/IndexTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/IndexTest.java
@@ -539,7 +539,7 @@ public class IndexTest extends PowerMockTestCase {
         final CountDownLatch signal = new CountDownLatch(2);
         addDummyObjects(3000);
         final Query query = new Query();
-        query.set("numericFilters", "dummy < 1500");
+        query.setNumericFilters(new JSONArray().put("dummy < 1500"));
         index.deleteByQueryAsync(query, new CompletionHandler() {
             @Override
             public void requestCompleted(JSONObject content, AlgoliaException error) {

--- a/algoliasearch/src/test/java/com/algolia/search/saas/QueryTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/QueryTest.java
@@ -598,4 +598,28 @@ public class QueryTest extends RobolectricTestCase  {
         Query query2 = Query.parse(query1.build());
         assertEquals(query2.getMinimumAroundRadius(), query1.getMinimumAroundRadius());
     }
+
+    @Test
+    public void test_numericFilters() throws JSONException {
+        final JSONArray VALUE = new JSONArray("[\"code=1\", [\"price:0 to 10\", \"price:1000 to 2000\"]]");
+        Query query1 = new Query();
+        assertNull(query1.getNumericFilters());
+        query1.setNumericFilters(VALUE);
+        assertEquals(query1.getNumericFilters(), VALUE);
+        assertEquals(query1.get("numericFilters"), "[\"code=1\",[\"price:0 to 10\",\"price:1000 to 2000\"]]");
+        Query query2 = Query.parse(query1.build());
+        assertEquals(query2.getNumericFilters(), query1.getNumericFilters());
+    }
+
+    @Test
+    public void test_filters() {
+        final String VALUE = "available=1 AND (category:Book OR NOT category:Ebook) AND publication_date: 1441745506 TO 1441755506 AND inStock > 0 AND author:\"John Doe\"";
+        Query query1 = new Query();
+        assertNull(query1.getFilters());
+        query1.setFilters(VALUE);
+        assertEquals(query1.getFilters(), VALUE);
+        assertEquals(query1.get("filters"), VALUE);
+        Query query2 = Query.parse(query1.build());
+        assertEquals(query2.getFilters(), query1.getFilters());
+    }
 }


### PR DESCRIPTION
The rationale for not implementing them was that they cannot be adequately typed. However, after investigation:

- `numericFilters` has roughly the same complexity as `tagFilters` or `facetFilters`. Therefore using a JSON array type, like for those parameters, should be adequate (although suboptimal).

- `filters` is designed to be a “SQL-like notation”, so I guess a raw string type is adequate. In the future, we may want to provide tools to build the filters more easily, but this will likely come in the form of “helpers”, as it is done in the Javascript client.

Since the absence of typed accessors for the missing parameters was confusing, I am adding them now.