### PR TITLE
Query: Expose parseLatLng method

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,10 @@
 Change Log
 ==========
 
+## Next version
+
+- Expose parseLatLng method
+
 ## 3.4.0 (2016-09-05)
 
 - Implement new user-agent convention

--- a/algoliasearch/src/main/java/com/algolia/search/saas/Query.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/Query.java
@@ -261,19 +261,7 @@ public class Query {
     }
 
     public LatLng getAroundLatLng() {
-        String value = get(KEY_AROUND_LAT_LNG);
-        if (value == null) {
-            return null;
-        }
-        String[] components = value.split(",");
-        if (components.length != 2) {
-            return null;
-        }
-        try {
-            return new LatLng(Double.valueOf(components[0]), Double.valueOf(components[1]));
-        } catch (NumberFormatException e) {
-            return null;
-        }
+        return parseLatLng(get(KEY_AROUND_LAT_LNG));
     }
 
     private static final String KEY_AROUND_LAT_LNG_VIA_IP = "aroundLatLngViaIP";
@@ -1228,6 +1216,26 @@ public class Query {
 
     private static String[] parseCommaArray(String string) {
         return string == null ? null : string.split(",");
+    }
+
+    /**
+     * Parse a LatLng from its String equivalent.
+     * @param value a String containing latitude/longitude.
+     * @return a LatLng object describing the given value.
+     */
+    @Nullable public LatLng parseLatLng(String value) {
+        if (value == null) {
+            return null;
+        }
+        String[] components = value.split(",");
+        if (components.length != 2) {
+            return null;
+        }
+        try {
+            return new LatLng(Double.valueOf(components[0]), Double.valueOf(components[1]));
+        } catch (NumberFormatException e) {
+            return null;
+        }
     }
 
     // ----------------------------------------------------------------------

--- a/algoliasearch/src/main/java/com/algolia/search/saas/Query.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/Query.java
@@ -1223,7 +1223,7 @@ public class Query {
      * @param value a String containing latitude/longitude.
      * @return a LatLng object describing the given value.
      */
-    @Nullable public LatLng parseLatLng(String value) {
+    @Nullable public static LatLng parseLatLng(String value) {
         if (value == null) {
             return null;
         }


### PR DESCRIPTION
This allows to reuse the parsing method when manipulating search results, avoiding [duplicated code in instantsearch-android](https://github.com/algolia/instantsearch-android/blob/master/instantsearch/src/main/java/com/algolia/instantsearch/model/SearchResults.java#L152-L166).