### PR TITLE
Share `Index` instances

### DIFF
--- a/algoliasearch/src/offline/java/com/algolia/search/saas/OfflineClient.java
+++ b/algoliasearch/src/offline/java/com/algolia/search/saas/OfflineClient.java
@@ -29,6 +29,7 @@ import android.support.annotation.NonNull;
 import com.algolia.search.offline.core.Sdk;
 
 import java.io.File;
+import java.lang.ref.WeakReference;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -110,13 +111,42 @@ public class OfflineClient extends Client
     /**
      * Create a new index. Although this will always be an instance of {@link MirroredIndex}, mirroring is deactivated
      * by default.
+     *
      * @param indexName the name of index
      * @return The newly created index.
+     *
+     * @deprecated You should now use {@link #getIndex(String)}, which re-uses instances with the same name.
      */
     @Override
     public MirroredIndex initIndex(@NonNull String indexName)
     {
         return new MirroredIndex(this, indexName);
+    }
+
+    /**
+     * Obtain a mirrored index. Although this will always be an instance of {@link MirroredIndex}, mirroring is
+     * deactivated by default.
+     *
+     * @param indexName The name of the index.
+     * @return A proxy to the specified index.
+     */
+    @Override
+    public @NonNull MirroredIndex getIndex(@NonNull String indexName) {
+        MirroredIndex index = null;
+        WeakReference<Index> existingIndex = indices.get(indexName);
+        if (existingIndex != null) {
+            Index anIndex = existingIndex.get();
+            if (anIndex != null && !(anIndex instanceof MirroredIndex)) {
+                throw new IllegalStateException("An index with the same name but a different type has already been created");
+            } else {
+                index = (MirroredIndex)anIndex;
+            }
+        }
+        if (index == null) {
+            index = new MirroredIndex(this, indexName);
+            indices.put(indexName, new WeakReference<Index>(index));
+        }
+        return index;
     }
 
     /**

--- a/algoliasearch/src/offline/java/com/algolia/search/saas/OfflineClient.java
+++ b/algoliasearch/src/offline/java/com/algolia/search/saas/OfflineClient.java
@@ -135,12 +135,7 @@ public class OfflineClient extends Client
         MirroredIndex index = null;
         WeakReference<Index> existingIndex = indices.get(indexName);
         if (existingIndex != null) {
-            Index anIndex = existingIndex.get();
-            if (anIndex != null && !(anIndex instanceof MirroredIndex)) {
-                throw new IllegalStateException("An index with the same name but a different type has already been created");
-            } else {
-                index = (MirroredIndex)anIndex;
-            }
+            index = (MirroredIndex)existingIndex.get();
         }
         if (index == null) {
             index = new MirroredIndex(this, indexName);

--- a/algoliasearch/src/test/java/com/algolia/search/saas/ClientTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/ClientTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2016 Algolia
+ * http://www.algolia.com/
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.algolia.search.saas;
+
+import android.annotation.SuppressLint;
+
+import org.junit.Test;
+import org.mockito.internal.util.reflection.Whitebox;
+import org.robolectric.util.concurrent.RoboExecutorService;
+
+import java.lang.ref.WeakReference;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * <a href="http://d.android.com/tools/testing/testing_android.html">Testing Fundamentals</a>
+ */
+
+@SuppressLint("DefaultLocale") //We use format for logging errors, locale issues are irrelevant
+public class ClientTest extends PowerMockTestCase {
+    Client client;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        client = new Client(Helpers.app_id, Helpers.api_key);
+        // WARNING: Robolectric cannot work with custom executors in `AsyncTask`, so we substitute the client's
+        // executor with a Robolectric-compliant one.
+        Whitebox.setInternalState(client, "searchExecutorService", new RoboExecutorService());
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void testIndexReuse() throws Exception {
+        Map<String, WeakReference<Index>> indices = (Map<String, WeakReference<Index>>)Whitebox.getInternalState(client, "indices");
+        final String indexName = "name";
+
+        // Ask for the same index twice and check that it is re-used.
+        assertEquals(0, indices.size());
+        Index index1 = client.getIndex(indexName);
+        assertEquals(1, indices.size());
+        Index index2 = client.getIndex(indexName);
+        assertEquals(index1, index2);
+        assertEquals(1, indices.size());
+
+        // Release the index and check that the reference is null.
+        // NOTE: This ought to work (works with a simple test case)... but does not.
+        // Keeping the code for the sake of completeness.
+        /*
+        index1 = null;
+        index2 = null;
+        System.gc();
+        assertNull(indices.get(indexName).get());
+        */
+    }
+}


### PR DESCRIPTION
Each `Client` keeps a map of already created indices, with the index name as the key and a weak reference to the index as a value. When asked for an index with the same name, it returns the already created one, unless it has been garbage-collected.

NOTE: In the tests, running the garbage collector does not finalize the index, although it ought to work (it does on a simple example). However, the debugger is positive that the only reference to the object is the weak map. => We’ll assume it should work in the real world… :/