### PR TITLE
Fix/travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
 android:
   components:
     - tools
-    - build-tools-24.0.1
+    - build-tools-24.0.3
     - android-24
     - extra-android-support
     - extra-android-m2repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ branches:
 sudo: false # Explicitely choose container-based infrastructure, see https://docs.travis-ci.com/user/ci-environment/
 language: android
 jdk:
-  - oraclejdk7
+  - oraclejdk8
 env:
   global:
     - secure: DENCjlvzW54U9QH7mWO3LJVLYEiX0Mj9U44QoGQcienflSDlVN1UhAiT7xnCKwWT38B37CzeQlHc541z78vAj+YPzPbebowFW0aiq/LNdFMigsT1j3gLpqrICjylG08i1Ho95FLCOaJSQWZJ5nSd3OceWLLxCYUXtS9E3BuMHGg=

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ android:
     - tools
     - build-tools-24.0.1
     - android-24
+    - extra-android-support
+    - extra-android-m2repository
 cache:
   directories:
     - $HOME/.gradle/caches/

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,14 +15,14 @@ env:
     - ANDROID_TARGET=android-16
     - ANDROID_TARGET=android-19
     - ANDROID_TARGET=android-21
-    - ANDROID_TARGET=android-23
+    - ANDROID_TARGET=android-24
 matrix:
   fast_finish: true
 android:
   components:
     - tools
-    - build-tools-23.0.3
-    - android-23
+    - build-tools-24.0.1
+    - android-24
 cache:
   directories:
     - $HOME/.gradle/caches/

--- a/algoliasearch/common.gradle
+++ b/algoliasearch/common.gradle
@@ -33,7 +33,7 @@ android {
     compileSdkVersion 24
     buildToolsVersion "24.0.1"
     defaultConfig {
-        minSdkVersion 7
+        minSdkVersion 10
         targetSdkVersion 24
         versionCode 1
         versionName PUBLISH_VERSION

--- a/algoliasearch/common.gradle
+++ b/algoliasearch/common.gradle
@@ -31,7 +31,7 @@ ext {
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "24.0.1"
+    buildToolsVersion "24.0.3"
     defaultConfig {
         minSdkVersion 10
         targetSdkVersion 24

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Apr 26 15:10:41 CEST 2016
+#Fri Sep 30 13:34:29 CEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
- ### Update `.travis.yml` to match `build.gradle` requirements  

- ### Update `.travis.yml` to build using Java8
It seems [this is now needed](https://github.com/OneBusAway/onebusaway-android/issues/699) when using the latest gradle plugin to avoid an `UnsupportedClassVersionError `.  

- ### Update minSdkVersion to 10
AppCompat moved to `minSdkVersion=10` which prevents the build:
> Manifest merger failed : uses-sdk:minSdkVersion 7 cannot be smaller than version 9 declared in library [com.android.support:appcompat-v7:24.2.1]

I could use `tools:overrideLibrary="android.support.v7.appcompat"` to force usage of AppCompat ignoring its minSdk, but I find no clear explanation of what it does and of the eventual risks.   
 Considering `minSdkVersion=10` is compatible with [99.9% of Android phones according to Google](https://developer.android.com/about/dashboards/index.html), let's err on the side of safety.  


