### PR TITLE
ignorePlurals: Also accept list of language ISO codes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,8 @@ Change Log
 ### New features
 
 - (#163) Search in your facets values with `Index.searchForFacetValues`
+- (#178) Accept a list of language ISO codes for ignorePlurals. **Note**: this introduces backward-incompatible changes.
+
 
 ## 3.6.0 (2016-11-10)
 

--- a/algoliasearch/src/main/java/com/algolia/search/saas/Query.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/Query.java
@@ -546,7 +546,7 @@ public class Query extends AbstractQuery {
      * If set to true, plural won't be considered as a typo (for example
      * car/cars will be considered as equals). Default to false.
      */
-    public @NonNull Query setIgnorePlurals(Boolean enabled) {
+    public @NonNull Query setIgnorePlurals(boolean enabled) {
         return set(KEY_IGNORE_PLURALS, enabled);
     }
 

--- a/algoliasearch/src/main/java/com/algolia/search/saas/Query.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/Query.java
@@ -458,7 +458,7 @@ public class Query extends AbstractQuery {
         }
 
         /**
-         * Construct an IgnorePlurals object for a String value.
+         * Construct an IgnorePlurals object for some language codes.
          *
          * @param codes one or several language codes to ignore plurals from.
          *              if {@code null}, the engine will ignore plurals in all supported languages.
@@ -547,7 +547,7 @@ public class Query extends AbstractQuery {
     }
 
     /**
-     * A list of languages for which plural won't be considered as a typo (for example
+     * A list of language codes for which plural won't be considered as a typo (for example
      * car/cars will be considered as equals). If empty or null, this disables the feature.
      */
     public
@@ -557,7 +557,7 @@ public class Query extends AbstractQuery {
     }
 
     /**
-     * A comma-separated list of languages for which plural won't be considered as a typo (for example
+     * One or several language codes for which plural won't be considered as a typo (for example
      * car/cars will be considered as equals). If empty or null, this disables the feature.
      */
     public

--- a/algoliasearch/src/main/java/com/algolia/search/saas/Query.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/Query.java
@@ -441,7 +441,7 @@ public class Query extends AbstractQuery {
          *
          * @param b if {@code true}, the engine will ignore plurals in all supported languages.
          */
-        public IgnorePlurals(Boolean b) {
+        public IgnorePlurals(boolean b) {
             this.enabled = b;
             languageCodes = null;
         }

--- a/algoliasearch/src/main/java/com/algolia/search/saas/Query.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/Query.java
@@ -452,9 +452,9 @@ public class Query extends AbstractQuery {
          * @param codes a list of language codes to ignore plurals from. if {@code null},
          *              the engine will ignore plurals in all supported languages.
          */
-        public IgnorePlurals(Collection<String> codes) {
+        public IgnorePlurals(@Nullable Collection<String> codes) {
             this.enabled = !isEmptyCollection(codes);
-            languageCodes = new ArrayList<>(codes);
+            languageCodes = codes != null ? new ArrayList<>(codes) : null;
         }
 
         /**
@@ -467,7 +467,7 @@ public class Query extends AbstractQuery {
             this(codes == null ? null : Arrays.asList(codes));
         }
 
-        private boolean isEmptyCollection(Collection<String> codesList) {
+        private boolean isEmptyCollection(@Nullable Collection<String> codesList) {
             return codesList == null || codesList.size() == 0;
         }
 
@@ -484,7 +484,7 @@ public class Query extends AbstractQuery {
             }
         }
 
-        static IgnorePlurals parse(String s) {
+        static @NonNull IgnorePlurals parse(String s) {
             if (s == null || s.length() == 0 || s.equals("null")) {
                 return new IgnorePlurals(false);
             } else if ("true".equals(s) || "false".equals(s)) {
@@ -542,7 +542,9 @@ public class Query extends AbstractQuery {
      * If set to true, plural won't be considered as a typo (for example
      * car/cars will be considered as equals). Default to false.
      */
-    public @NonNull Query setIgnorePlurals(boolean enabled) {
+    public
+    @NonNull
+    Query setIgnorePlurals(boolean enabled) {
         return set(KEY_IGNORE_PLURALS, enabled);
     }
 
@@ -552,7 +554,7 @@ public class Query extends AbstractQuery {
      */
     public
     @NonNull
-    Query setIgnorePlurals(Collection<String> languageISOCodes) {
+    Query setIgnorePlurals(@Nullable Collection<String> languageISOCodes) {
         return set(KEY_IGNORE_PLURALS, new IgnorePlurals(languageISOCodes));
     }
 
@@ -562,11 +564,11 @@ public class Query extends AbstractQuery {
      */
     public
     @NonNull
-    Query setIgnorePlurals(String languageISOCodes) {
+    Query setIgnorePlurals(@Nullable String... languageISOCodes) {
         return set(KEY_IGNORE_PLURALS, new IgnorePlurals(languageISOCodes));
     }
 
-    public IgnorePlurals getIgnorePlurals() {
+    public @NonNull IgnorePlurals getIgnorePlurals() {
         return IgnorePlurals.parse(get(KEY_IGNORE_PLURALS));
     }
 

--- a/algoliasearch/src/main/java/com/algolia/search/saas/Query.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/Query.java
@@ -8,6 +8,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -445,18 +446,14 @@ public class Query extends AbstractQuery {
         }
 
         /**
-         * Construct an IgnorePlurals object for a List of codes.
+         * Construct an IgnorePlurals object for a {@link Collection} of language codes.
          *
-         * @param codesList a list of language codes to ignore plurals from. if {@code null},
-         *                  the engine will ignore plurals in all supported languages.
+         * @param codes a list of language codes to ignore plurals from. if {@code null},
+         *              the engine will ignore plurals in all supported languages.
          */
-        public IgnorePlurals(List<String> codesList) {
-            if (isEmptyList(codesList)) {
-                this.enabled = false;
-            } else {
-                this.enabled = true;
-            }
-            languageCodes = codesList;
+        public IgnorePlurals(Collection<String> codes) {
+            this.enabled = !isEmptyCollection(codes);
+            languageCodes = new ArrayList<>(codes);
         }
 
         /**
@@ -471,7 +468,7 @@ public class Query extends AbstractQuery {
             languageCodes = parsed.languageCodes;
         }
 
-        private boolean isEmptyList(List<String> codesList) {
+        private boolean isEmptyCollection(Collection<String> codesList) {
             return codesList == null || codesList.size() == 0;
         }
 
@@ -480,7 +477,7 @@ public class Query extends AbstractQuery {
             if (!enabled) {
                 return "false";
             } else {
-                if (isEmptyList(languageCodes)) {  // enabled without specific language
+                if (isEmptyCollection(languageCodes)) {  // enabled without specific language
                     return "true";
                 } else {
                     return TextUtils.join(",", languageCodes);
@@ -556,7 +553,7 @@ public class Query extends AbstractQuery {
      */
     public
     @NonNull
-    Query setIgnorePlurals(List<String> languageISOCodes) {
+    Query setIgnorePlurals(Collection<String> languageISOCodes) {
         return set(KEY_IGNORE_PLURALS, new IgnorePlurals(languageISOCodes));
     }
 

--- a/algoliasearch/src/main/java/com/algolia/search/saas/Query.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/Query.java
@@ -8,6 +8,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -459,13 +460,11 @@ public class Query extends AbstractQuery {
         /**
          * Construct an IgnorePlurals object for a String value.
          *
-         * @param codesList a list of language codes to ignore plurals from, separated by commas.
-         *                  if {@code null}, the engine will ignore plurals in all supported languages.
+         * @param codes one or several language codes to ignore plurals from.
+         *              if {@code null}, the engine will ignore plurals in all supported languages.
          */
-        public IgnorePlurals(String codesList) {
-            final IgnorePlurals parsed = parse(codesList);
-            enabled = parsed.enabled;
-            languageCodes = parsed.languageCodes;
+        public IgnorePlurals(@Nullable String... codes) {
+            this(codes == null ? null : Arrays.asList(codes));
         }
 
         private boolean isEmptyCollection(Collection<String> codesList) {

--- a/algoliasearch/src/test/java/com/algolia/search/saas/QueryTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/QueryTest.java
@@ -162,9 +162,6 @@ public class QueryTest extends RobolectricTestCase {
         assertFalse("By default, ignorePlurals should be disabled.", query.getIgnorePlurals().enabled);
 
         // Boolean values
-        query.setIgnorePlurals((Boolean) null);
-        assertFalse("A null boolean value should disable ignorePlurals.", query.getIgnorePlurals().enabled);
-
         query.setIgnorePlurals(true);
         assertEquals("A true boolean should enable ignorePlurals.", Boolean.TRUE, query.getIgnorePlurals().enabled);
         assertEquals("A true boolean should be built and parsed successfully.", query.getIgnorePlurals(), Query.parse(query.build()).getIgnorePlurals());
@@ -187,9 +184,9 @@ public class QueryTest extends RobolectricTestCase {
         assertNotNull("The language codes should not be null", query.getIgnorePlurals().languageCodes);
         assertEquals("Two language codes should be in ignorePlurals.", 2, query.getIgnorePlurals().languageCodes.size());
         assertTrue("The first language code should be in ignorePlurals", query.getIgnorePlurals().languageCodes.contains(languageCodes.get(0)));
-        assertTrue("The first language code should be in ignorePlurals", query.getIgnorePlurals().languageCodes.contains(languageCodes.get(1)));
+        assertTrue("The second language code should be in ignorePlurals", query.getIgnorePlurals().languageCodes.contains(languageCodes.get(1)));
 
-        // String values
+        // String[] values
         query.setIgnorePlurals("");
         assertFalse("An empty string should disable ignorePlurals.", query.getIgnorePlurals().enabled);
         assertEquals("A empty string should be built and parsed successfully.", query.getIgnorePlurals(), Query.parse(query.build()).getIgnorePlurals());
@@ -199,6 +196,13 @@ public class QueryTest extends RobolectricTestCase {
         assertEquals("A single language code should be built and parsed successfully.", query.getIgnorePlurals(), Query.parse(query.build()).getIgnorePlurals());
         assertEquals("One language code should be in ignorePlurals.", 1, query.getIgnorePlurals().languageCodes.size());
         assertTrue("The language code should be in ignorePlurals", query.getIgnorePlurals().languageCodes.contains("en"));
+
+        query.setIgnorePlurals("en", "fr");
+        assertEquals("Two language codes should enable ignorePlurals.", Boolean.TRUE, query.getIgnorePlurals().enabled);
+        assertEquals("Two language codes should be built and parsed successfully.", query.getIgnorePlurals(), Query.parse(query.build()).getIgnorePlurals());
+        assertEquals("Two language codes should be in ignorePlurals.", 2, query.getIgnorePlurals().languageCodes.size());
+        assertTrue("The first language code should be in ignorePlurals", query.getIgnorePlurals().languageCodes.contains("en"));
+        assertTrue("The second language code should be in ignorePlurals", query.getIgnorePlurals().languageCodes.contains("fr"));
     }
 
     @Test

--- a/algoliasearch/src/test/java/com/algolia/search/saas/QueryTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/QueryTest.java
@@ -27,6 +27,11 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertNotNull;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -36,7 +41,7 @@ import static org.junit.Assert.fail;
 /**
  * Unit tests for the `Query` class.
  */
-public class QueryTest extends RobolectricTestCase  {
+public class QueryTest extends RobolectricTestCase {
 
     // ----------------------------------------------------------------------
     // Build & parse
@@ -152,17 +157,48 @@ public class QueryTest extends RobolectricTestCase  {
 
     @Test
     public void test_ignorePlurals() {
-        Query query1 = new Query();
-        assertNull(query1.getIgnorePlurals());
-        query1.setIgnorePlurals(true);
-        assertEquals(query1.getIgnorePlurals(), Boolean.TRUE);
-        Query query2 = Query.parse(query1.build());
-        assertEquals(query2.getIgnorePlurals(), query1.getIgnorePlurals());
+        // No value
+        Query query = new Query();
+        assertFalse("By default, ignorePlurals should be disabled.", query.getIgnorePlurals().enabled);
 
-        query1.setIgnorePlurals(false);
-        assertEquals(query1.getIgnorePlurals(), Boolean.FALSE);
-        Query query3 = Query.parse(query1.build());
-        assertEquals(query3.getIgnorePlurals(), query1.getIgnorePlurals());
+        // Boolean values
+        query.setIgnorePlurals((Boolean) null);
+        assertFalse("A null boolean value should disable ignorePlurals.", query.getIgnorePlurals().enabled);
+
+        query.setIgnorePlurals(true);
+        assertEquals("A true boolean should enable ignorePlurals.", Boolean.TRUE, query.getIgnorePlurals().enabled);
+        assertEquals("A true boolean should be built and parsed successfully.", query.getIgnorePlurals(), Query.parse(query.build()).getIgnorePlurals());
+
+        query.setIgnorePlurals(false);
+        assertEquals("A false boolean should disable ignorePlurals.", Boolean.FALSE, query.getIgnorePlurals().enabled);
+        assertEquals("A false boolean should be built and parsed successfully.", query.getIgnorePlurals(), Query.parse(query.build()).getIgnorePlurals());
+
+        // List values
+        query.setIgnorePlurals((List<String>) null);
+        assertFalse("A null list value should disable ignorePlurals.", query.getIgnorePlurals().enabled);
+        assertEquals("A null list value should be built and parsed successfully.", query.getIgnorePlurals(), Query.parse(query.build()).getIgnorePlurals());
+
+        query.setIgnorePlurals(new ArrayList<String>());
+        assertFalse("Setting an empty list should disable ignorePlurals.", query.getIgnorePlurals().enabled);
+
+        ArrayList<String> languageCodes = new ArrayList<>(java.util.Arrays.asList("en", "fr"));
+        query.setIgnorePlurals(languageCodes);
+        assertTrue("Setting a non-empty list should enable ignorePlurals.", query.getIgnorePlurals().enabled);
+        assertNotNull("The language codes should not be null", query.getIgnorePlurals().languageCodes);
+        assertEquals("Two language codes should be in ignorePlurals.", 2, query.getIgnorePlurals().languageCodes.size());
+        assertTrue("The first language code should be in ignorePlurals", query.getIgnorePlurals().languageCodes.contains(languageCodes.get(0)));
+        assertTrue("The first language code should be in ignorePlurals", query.getIgnorePlurals().languageCodes.contains(languageCodes.get(1)));
+
+        // String values
+        query.setIgnorePlurals("");
+        assertFalse("An empty string should disable ignorePlurals.", query.getIgnorePlurals().enabled);
+        assertEquals("A empty string should be built and parsed successfully.", query.getIgnorePlurals(), Query.parse(query.build()).getIgnorePlurals());
+
+        query.setIgnorePlurals("en");
+        assertEquals("A single language code should enable ignorePlurals.", Boolean.TRUE, query.getIgnorePlurals().enabled);
+        assertEquals("A single language code should be built and parsed successfully.", query.getIgnorePlurals(), Query.parse(query.build()).getIgnorePlurals());
+        assertEquals("One language code should be in ignorePlurals.", 1, query.getIgnorePlurals().languageCodes.size());
+        assertTrue("The language code should be in ignorePlurals", query.getIgnorePlurals().languageCodes.contains("en"));
     }
 
     @Test


### PR DESCRIPTION
Implement `ignorePlurals` as list of language codes.

You can now set this parameter using:

- `Query.setIgnorePlurals(true)` to enable the feature on all supported languages.
- `Query.setIgnorePlurals("en", "fr")` to select languages via one or several Strings (or a String array).
- `Query.setIgnorePlurals(Arrays.asList("en", "fr"))` to select languages via a `Collection` of Strings.