### PR TITLE
Cleanup tests

### DIFF
--- a/algoliasearch/src/test/java/com/algolia/search/saas/BrowseIteratorTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/BrowseIteratorTest.java
@@ -76,7 +76,7 @@ public class BrowseIteratorTest extends RobolectricTestCase {
     }
 
     @Test
-    public void testNominal() throws Exception {
+    public void nominal() throws Exception {
         Query query = new Query();
         AssertBrowseHandler handler = new AssertBrowseHandler() {
             @Override
@@ -93,7 +93,7 @@ public class BrowseIteratorTest extends RobolectricTestCase {
     }
 
     @Test
-    public void testCancel() throws Exception {
+    public void cancel() throws Exception {
         Query query = new Query();
         AssertBrowseHandler handler = new AssertBrowseHandler() {
             @Override

--- a/algoliasearch/src/test/java/com/algolia/search/saas/IndexTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/IndexTest.java
@@ -177,10 +177,10 @@ public class IndexTest extends RobolectricTestCase {
         index.waitTask(task.getString("taskID"));
 
         final Query query = new Query("phone").setFacets("brand", "category", "stars");
-        final List<String> disjunctiveFacets = Arrays.asList("brand");
+        final List<String> disjunctiveFacets = Collections.singletonList("brand");
         final Map<String, List<String>> refinements = new HashMap<>();
         refinements.put("brand", Arrays.asList("Apple", "Samsung")); // disjunctive facet
-        refinements.put("category", Arrays.asList("device")); // conjunctive facet
+        refinements.put("category", Collections.singletonList("device")); // conjunctive facet
         index.searchDisjunctiveFacetingAsync(query, disjunctiveFacets, refinements, new AssertCompletionHandler() {
             @Override
             public void doRequestCompleted(JSONObject content, AlgoliaException error) {
@@ -229,7 +229,7 @@ public class IndexTest extends RobolectricTestCase {
             }
         });
 
-        refinements.put("stars", Arrays.asList("*"));
+        refinements.put("stars", Collections.singletonList("*"));
         index.searchDisjunctiveFacetingAsync(query, disjunctiveFacets, refinements, new AssertCompletionHandler() {
             @Override
             public void doRequestCompleted(JSONObject content, AlgoliaException error) {
@@ -242,7 +242,7 @@ public class IndexTest extends RobolectricTestCase {
             }
         });
 
-        refinements.put("city", Arrays.asList("Paris"));
+        refinements.put("city", Collections.singletonList("Paris"));
         index.searchDisjunctiveFacetingAsync(query, disjunctiveFacets, refinements, new AssertCompletionHandler() {
             @Override
             public void doRequestCompleted(JSONObject content, AlgoliaException error) {

--- a/algoliasearch/src/test/java/com/algolia/search/saas/IndexTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/IndexTest.java
@@ -83,7 +83,7 @@ public class IndexTest extends RobolectricTestCase {
 
         client.deleteIndex(indexName);
 
-        objects = new ArrayList<JSONObject>();
+        objects = new ArrayList<>();
         objects.add(new JSONObject("{\"city\": \"San Francisco\"}"));
         objects.add(new JSONObject("{\"city\": \"San José\"}"));
 
@@ -91,7 +91,7 @@ public class IndexTest extends RobolectricTestCase {
         index.waitTask(task.getString("taskID"));
 
         JSONArray objectIDs = task.getJSONArray("objectIDs");
-        ids = new ArrayList<String>();
+        ids = new ArrayList<>();
         for (int i = 0; i < objectIDs.length(); ++i) {
             ids.add(objectIDs.getString(i));
         }
@@ -386,7 +386,7 @@ public class IndexTest extends RobolectricTestCase {
 
     @Test
     public void getObjectWithAttributesToRetrieveAsync() throws Exception {
-        List<String> attributesToRetrieve = new ArrayList<String>();
+        List<String> attributesToRetrieve = new ArrayList<>();
         attributesToRetrieve.add("objectID");
         index.getObjectAsync(ids.get(0), attributesToRetrieve, new AssertCompletionHandler() {
             @Override public void doRequestCompleted(JSONObject content, AlgoliaException error) {
@@ -621,7 +621,7 @@ public class IndexTest extends RobolectricTestCase {
 
     private void addDummyObjects(int objectCount) throws Exception {
         // Construct an array of dummy objects.
-        objects = new ArrayList<JSONObject>();
+        objects = new ArrayList<>();
         for (int i = 0; i < objectCount; ++i) {
             objects.add(new JSONObject(String.format("{\"dummy\": %d}", i)));
         }

--- a/algoliasearch/src/test/java/com/algolia/search/saas/IndexTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/IndexTest.java
@@ -109,11 +109,11 @@ public class IndexTest extends RobolectricTestCase {
     }
 
     @Test
-    public void testSearchAsync() throws Exception {
-        testSearchAsync(Helpers.wait);
+    public void searchAsync() throws Exception {
+        searchAsync(Helpers.wait);
     }
 
-    public void testSearchAsync(int waitTimeoutSeconds) throws Exception {
+    public void searchAsync(int waitTimeoutSeconds) throws Exception {
         final long begin = System.nanoTime();
         // Empty search.
         index.searchAsync(new Query(), new AssertCompletionHandler() {
@@ -143,7 +143,7 @@ public class IndexTest extends RobolectricTestCase {
     }
 
     @Test
-    public void testSearchDisjunctiveFacetingAsync() throws Exception {
+    public void searchDisjunctiveFacetingAsync() throws Exception {
         // Set index settings.
         JSONObject setSettingsResult = index.setSettings(new JSONObject("{\"attributesForFaceting\": [\"brand\", \"category\"]}"));
         index.waitTask(setSettingsResult.getString("taskID"));
@@ -201,7 +201,7 @@ public class IndexTest extends RobolectricTestCase {
     }
 
     @Test
-    public void testDisjunctiveFacetingAsync2() throws Exception {
+    public void disjunctiveFacetingAsync2() throws Exception {
         // Set index settings.
         JSONObject setSettingsResult = index.setSettings(new JSONObject("{\"attributesForFaceting\":[\"city\", \"stars\", \"facilities\"]}"));
         index.waitTask(setSettingsResult.getString("taskID"));
@@ -269,7 +269,7 @@ public class IndexTest extends RobolectricTestCase {
     }
 
     @Test
-    public void testAggregateResultsPropagatesNonExhaustiveCount() throws Exception {
+    public void aggregateResultsPropagatesNonExhaustiveCount() throws Exception {
         try {
             List<String> disjunctiveFacets = new ArrayList<>();
             Map<String, List<String>> refinements = new HashMap<>();
@@ -304,7 +304,7 @@ public class IndexTest extends RobolectricTestCase {
     }
 
     @Test
-    public void testAddObjectAsync() throws Exception {
+    public void addObjectAsync() throws Exception {
         index.addObjectAsync(new JSONObject("{\"city\": \"New York\"}"), new AssertCompletionHandler() {
             @Override public void doRequestCompleted(JSONObject content, AlgoliaException error) {
                 if (error == null) {
@@ -317,7 +317,7 @@ public class IndexTest extends RobolectricTestCase {
     }
 
     @Test
-    public void testAddObjectWithObjectIDAsync() throws Exception {
+    public void addObjectWithObjectIDAsync() throws Exception {
         index.addObjectAsync(new JSONObject("{\"city\": \"New York\"}"), "a1b2c3", new AssertCompletionHandler() {
             @Override public void doRequestCompleted(JSONObject content, AlgoliaException error) {
                 if (error == null) {
@@ -330,7 +330,7 @@ public class IndexTest extends RobolectricTestCase {
     }
 
     @Test
-    public void testAddObjectsAsync() throws Exception {
+    public void addObjectsAsync() throws Exception {
         index.addObjectsAsync(new JSONArray("[{\"city\": \"New York\"}, {\"city\": \"Paris\"}]"), new AssertCompletionHandler() {
             @Override public void doRequestCompleted(JSONObject content, AlgoliaException error) {
                 if (error == null) {
@@ -343,7 +343,7 @@ public class IndexTest extends RobolectricTestCase {
     }
 
     @Test
-    public void testSaveObjectAsync() throws Exception {
+    public void saveObjectAsync() throws Exception {
         index.saveObjectAsync(new JSONObject("{\"city\": \"New York\"}"), "a1b2c3", new AssertCompletionHandler() {
             @Override public void doRequestCompleted(JSONObject content, AlgoliaException error) {
                 if (error == null) {
@@ -356,7 +356,7 @@ public class IndexTest extends RobolectricTestCase {
     }
 
     @Test
-    public void testSaveObjectsAsync() throws Exception {
+    public void saveObjectsAsync() throws Exception {
         index.saveObjectsAsync(new JSONArray("[{\"city\": \"New York\", \"objectID\": 123}, {\"city\": \"Paris\", \"objectID\": 456}]"), new AssertCompletionHandler() {
             @Override public void doRequestCompleted(JSONObject content, AlgoliaException error) {
                 if (error == null) {
@@ -371,7 +371,7 @@ public class IndexTest extends RobolectricTestCase {
     }
 
     @Test
-    public void testGetObjectAsync() throws Exception {
+    public void getObjectAsync() throws Exception {
         index.getObjectAsync(ids.get(0), new AssertCompletionHandler() {
             @Override public void doRequestCompleted(JSONObject content, AlgoliaException error) {
                 if (error == null) {
@@ -385,7 +385,7 @@ public class IndexTest extends RobolectricTestCase {
     }
 
     @Test
-    public void testGetObjectWithAttributesToRetrieveAsync() throws Exception {
+    public void getObjectWithAttributesToRetrieveAsync() throws Exception {
         List<String> attributesToRetrieve = new ArrayList<String>();
         attributesToRetrieve.add("objectID");
         index.getObjectAsync(ids.get(0), attributesToRetrieve, new AssertCompletionHandler() {
@@ -401,7 +401,7 @@ public class IndexTest extends RobolectricTestCase {
     }
 
     @Test
-    public void testGetObjectsAsync() throws Exception {
+    public void getObjectsAsync() throws Exception {
         index.getObjectsAsync(ids, new AssertCompletionHandler() {
             @Override public void doRequestCompleted(JSONObject content, AlgoliaException error) {
                 if (error == null) {
@@ -417,7 +417,7 @@ public class IndexTest extends RobolectricTestCase {
     }
 
     @Test
-    public void testWaitTaskAsync() throws Exception {
+    public void waitTaskAsync() throws Exception {
         index.addObjectAsync(new JSONObject("{\"city\": \"New York\"}"), new AssertCompletionHandler() {
             @Override public void doRequestCompleted(JSONObject content, AlgoliaException error) {
                 if (error == null) {
@@ -439,18 +439,18 @@ public class IndexTest extends RobolectricTestCase {
     }
 
     @Test
-    public void testHostSwitch() throws Exception {
+    public void hostSwitch() throws Exception {
         // Given first host as an unreachable domain
         List<String> hostsArray = (List<String>) Whitebox.getInternalState(client, "readHosts");
         hostsArray.set(0, "thissentenceshouldbeuniqueenoughtoguaranteeinexistentdomain.com");
         Whitebox.setInternalState(client, "readHosts", hostsArray);
 
         // Expect a switch to the next URL and successful search
-        testSearchAsync();
+        searchAsync();
     }
 
     @Test
-    public void testDNSTimeout() throws Exception {
+    public void DNSTimeout() throws Exception {
         // On Travis, the imposed DNS timeout prevents us from testing this feature.
         if ("true".equals(System.getenv("TRAVIS"))) {
             return;
@@ -470,7 +470,7 @@ public class IndexTest extends RobolectricTestCase {
 
         // Expect successful search within 5 seconds
         long startTime = System.nanoTime();
-        testSearchAsync(5);
+        searchAsync(5);
         final long duration = (System.nanoTime() - startTime) / 1000000;
 
         // Which should take at least 2 seconds, as per Client.connectTimeout
@@ -478,16 +478,16 @@ public class IndexTest extends RobolectricTestCase {
     }
 
     @Test
-    public void testConnectTimeout() throws AlgoliaException {
-        testConnectTimeout(1);
+    public void connectTimeout() throws AlgoliaException {
+        connectTimeout(1);
     }
 
     @Test
-    public void testMultipleConnectTimeout() throws AlgoliaException {
-        testConnectTimeout(2);
+    public void multipleConnectTimeout() throws AlgoliaException {
+        connectTimeout(2);
     }
 
-    private void testConnectTimeout(int nbHosts) throws AlgoliaException {
+    private void connectTimeout(int nbHosts) throws AlgoliaException {
         // On Travis, the reported run duration is not reliable.
         if ("true".equals(System.getenv("TRAVIS"))) {
             return;
@@ -514,7 +514,7 @@ public class IndexTest extends RobolectricTestCase {
 
 
     @Test
-    public void testConnectionResetException() throws IOException, AlgoliaException {
+    public void connectionResetException() throws IOException, AlgoliaException {
         Thread runnable = new Thread() {
             @Override
             public void run() {
@@ -545,7 +545,7 @@ public class IndexTest extends RobolectricTestCase {
     }
 
     @Test
-    public void testSNI() throws Exception {
+    public void SNI() throws Exception {
         // Given all hosts using SNI
         String appId = (String) Whitebox.getInternalState(client, "applicationID");
         List<String> hostsArray = (List<String>) Whitebox.getInternalState(client, "readHosts");
@@ -556,11 +556,11 @@ public class IndexTest extends RobolectricTestCase {
         Whitebox.setInternalState(client, "readHosts", hostsArray);
 
         // Expect correct certificate handling and successful search
-        testSearchAsync();
+        searchAsync();
     }
 
     @Test
-    public void testKeepAlive() throws Exception {
+    public void keepAlive() throws Exception {
         // On Travis, the reported run duration is not reliable.
         if ("true".equals(System.getenv("TRAVIS"))) {
             return;
@@ -632,7 +632,7 @@ public class IndexTest extends RobolectricTestCase {
     }
 
     @Test
-    public void testBrowseAsync() throws Exception {
+    public void browseAsync() throws Exception {
         addDummyObjects(1500);
         Query query = new Query().setHitsPerPage(1000);
         index.browseAsync(query, new AssertCompletionHandler() {
@@ -659,7 +659,7 @@ public class IndexTest extends RobolectricTestCase {
     }
 
     @Test
-    public void testClearIndexAsync() throws Exception {
+    public void clearIndexAsync() throws Exception {
         index.clearIndexAsync(new AssertCompletionHandler() {
             @Override
             public void doRequestCompleted(JSONObject content, AlgoliaException error) {
@@ -691,7 +691,7 @@ public class IndexTest extends RobolectricTestCase {
     }
 
     @Test
-    public void testDeleteByQueryAsync() throws Exception {
+    public void deleteByQueryAsync() throws Exception {
         addDummyObjects(3000);
         final Query query = new Query().setNumericFilters(new JSONArray().put("dummy < 1500"));
         index.deleteByQueryAsync(query, new AssertCompletionHandler() {
@@ -719,7 +719,7 @@ public class IndexTest extends RobolectricTestCase {
     }
 
     @Test
-    public void testError404() throws Exception {
+    public void error404() throws Exception {
         Index unknownIndex = client.initIndex("doesnotexist");
         unknownIndex.searchAsync(new Query(), new AssertCompletionHandler() {
             @Override
@@ -732,24 +732,24 @@ public class IndexTest extends RobolectricTestCase {
     }
 
     @Test
-    public void testCacheUseIfEnabled() throws Exception {
+    public void cacheUseIfEnabled() throws Exception {
         index.enableSearchCache();
         verifySearchTwiceCalls(1);
     }
 
     @Test
-    public void testCacheDontUseByDefault() throws Exception {
+    public void cacheDontUseByDefault() throws Exception {
         verifySearchTwiceCalls(2);
     }
 
     @Test
-    public void testCacheDontUseIfDisabled() throws Exception {
+    public void cacheDontUseIfDisabled() throws Exception {
         index.disableSearchCache();
         verifySearchTwiceCalls(2);
     }
 
     @Test
-    public void testCacheTimeout() throws Exception {
+    public void cacheTimeout() throws Exception {
         index.enableSearchCache(1, ExpiringCache.defaultMaxSize);
         verifySearchTwiceCalls(2, 2);
     }
@@ -786,13 +786,13 @@ public class IndexTest extends RobolectricTestCase {
     }
 
     @Test
-    public void testNullCompletionHandler() throws Exception {
+    public void nullCompletionHandler() throws Exception {
         // Check that the code does not crash when no completion handler is specified.
         index.addObjectAsync(new JSONObject("{\"city\": \"New York\"}"), null);
     }
 
     @Test
-    public void testMultipleQueries() throws Exception {
+    public void multipleQueries() throws Exception {
         final List<Query> queries = Arrays.asList(
                 new Query("francisco").setHitsPerPage(1),
                 new Query("jose")
@@ -819,7 +819,7 @@ public class IndexTest extends RobolectricTestCase {
     }
 
     @Test
-    public void testUserAgent() throws Exception {
+    public void userAgent() throws Exception {
         // Test the default value.
         String userAgent = (String) Whitebox.getInternalState(client, "userAgentRaw");
         assertTrue(userAgent.matches("^Algolia for Android \\([0-9.]+\\); Android \\(([0-9.]+(_r[0-9]+)?|unknown)\\)$"));
@@ -833,7 +833,7 @@ public class IndexTest extends RobolectricTestCase {
     }
 
     @Test
-    public void testGetObjectAttributes() throws AlgoliaException {
+    public void getObjectAttributes() throws AlgoliaException {
         for (String id : ids) {
             JSONObject object = index.getObject(id);
             assertEquals("The retrieved object should have two attributes.", 2, object.names().length());
@@ -844,7 +844,7 @@ public class IndexTest extends RobolectricTestCase {
     }
 
     @Test
-    public void testGetObjectsAttributes() throws AlgoliaException {
+    public void getObjectsAttributes() throws AlgoliaException {
         try {
             JSONArray results = index.getObjects(ids).getJSONArray("results");
             for (int i = 0; i < results.length(); i++) {
@@ -863,7 +863,7 @@ public class IndexTest extends RobolectricTestCase {
     }
 
     @Test
-    public void testPartialUpdateObject() throws Exception {
+    public void partialUpdateObject() throws Exception {
         JSONObject partialObject = new JSONObject().put("city", "Paris");
         index.partialUpdateObjectAsync(partialObject, ids.get(0), new AssertCompletionHandler() {
             @Override
@@ -888,7 +888,7 @@ public class IndexTest extends RobolectricTestCase {
     }
 
     @Test
-    public void testPartialUpdateObjectNoCreate() throws Exception {
+    public void partialUpdateObjectNoCreate() throws Exception {
         final String objectID = "unknown";
         final JSONObject partialObject = new JSONObject().put("city", "Paris");
 
@@ -938,7 +938,7 @@ public class IndexTest extends RobolectricTestCase {
     }
 
     @Test
-    public void testPartialUpdateObjects() throws Exception {
+    public void partialUpdateObjects() throws Exception {
         final JSONArray partialObjects = new JSONArray()
                 .put(new JSONObject().put("objectID", ids.get(0)).put("city", "Paris"))
                 .put(new JSONObject().put("objectID", ids.get(1)).put("city", "Berlin"));
@@ -972,7 +972,7 @@ public class IndexTest extends RobolectricTestCase {
     }
 
     @Test
-    public void testPartialUpdateObjectsNoCreate() throws Exception {
+    public void partialUpdateObjectsNoCreate() throws Exception {
         final List<String> newIds = Arrays.asList("unknown", "none");
         final JSONArray partialObjects = new JSONArray()
             .put(new JSONObject().put("objectID", newIds.get(0)).put("city", "Paris"))

--- a/algoliasearch/src/test/java/com/algolia/search/saas/IndexTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/IndexTest.java
@@ -79,7 +79,7 @@ public class IndexTest extends RobolectricTestCase {
         Whitebox.setInternalState(client, "searchExecutorService", new RoboExecutorService());
 
         indexName = Helpers.safeIndexName("àlgol?à-android");
-        index = client.initIndex(indexName);
+        index = client.getIndex(indexName);
 
         client.deleteIndex(indexName);
 
@@ -720,7 +720,7 @@ public class IndexTest extends RobolectricTestCase {
 
     @Test
     public void error404() throws Exception {
-        Index unknownIndex = client.initIndex("doesnotexist");
+        Index unknownIndex = client.getIndex("doesnotexist");
         unknownIndex.searchAsync(new Query(), new AssertCompletionHandler() {
             @Override
             public void doRequestCompleted(JSONObject content, AlgoliaException error) {

--- a/algoliasearch/src/test/java/com/algolia/search/saas/QueryTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/QueryTest.java
@@ -115,7 +115,7 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getMinWordSizefor1Typo());
         query1.setMinWordSizefor1Typo(123);
-        assertEquals(new Integer(123), query1.getMinWordSizefor1Typo());
+        assertEquals(Integer.valueOf(123), query1.getMinWordSizefor1Typo());
         Query query2 = Query.parse(query1.build());
         assertEquals(query1.getMinWordSizefor1Typo(), query2.getMinWordSizefor1Typo());
     }
@@ -125,7 +125,7 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getMinWordSizefor2Typos());
         query1.setMinWordSizefor2Typos(456);
-        assertEquals(new Integer(456), query1.getMinWordSizefor2Typos());
+        assertEquals(Integer.valueOf(456), query1.getMinWordSizefor2Typos());
         Query query2 = Query.parse(query1.build());
         assertEquals(query1.getMinWordSizefor2Typos(), query2.getMinWordSizefor2Typos());
     }
@@ -135,7 +135,7 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getMinProximity());
         query1.setMinProximity(999);
-        assertEquals(new Integer(999), query1.getMinProximity());
+        assertEquals(Integer.valueOf(999), query1.getMinProximity());
         Query query2 = Query.parse(query1.build());
         assertEquals(query1.getMinProximity(), query2.getMinProximity());
     }
@@ -210,7 +210,7 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getDistinct());
         query1.setDistinct(100);
-        assertEquals(new Integer(100), query1.getDistinct());
+        assertEquals(Integer.valueOf(100), query1.getDistinct());
         Query query2 = Query.parse(query1.build());
         assertEquals(query1.getDistinct(), query2.getDistinct());
     }
@@ -220,7 +220,7 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getPage());
         query1.setPage(0);
-        assertEquals(new Integer(0), query1.getPage());
+        assertEquals(Integer.valueOf(0), query1.getPage());
         Query query2 = Query.parse(query1.build());
         assertEquals(query1.getPage(), query2.getPage());
     }
@@ -230,7 +230,7 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getHitsPerPage());
         query1.setHitsPerPage(50);
-        assertEquals(new Integer(50), query1.getHitsPerPage());
+        assertEquals(Integer.valueOf(50), query1.getHitsPerPage());
         Query query2 = Query.parse(query1.build());
         assertEquals(query1.getHitsPerPage(), query2.getHitsPerPage());
     }
@@ -502,7 +502,7 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getAroundPrecision());
         query1.setAroundPrecision(12345);
-        assertEquals(new Integer(12345), query1.getAroundPrecision());
+        assertEquals(Integer.valueOf(12345), query1.getAroundPrecision());
         assertEquals("12345", query1.get("aroundPrecision"));
         Query query2 = Query.parse(query1.build());
         assertEquals(query1.getAroundPrecision(), query2.getAroundPrecision());
@@ -513,7 +513,7 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getAroundRadius());
         query1.setAroundRadius(987);
-        assertEquals(new Integer(987), query1.getAroundRadius());
+        assertEquals(Integer.valueOf(987), query1.getAroundRadius());
         assertEquals("987", query1.get("aroundRadius"));
         Query query2 = Query.parse(query1.build());
         assertEquals(query1.getAroundRadius(), query2.getAroundRadius());
@@ -649,7 +649,7 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getMaxValuesPerFacet());
         query1.setMaxValuesPerFacet(456);
-        assertEquals(new Integer(456), query1.getMaxValuesPerFacet());
+        assertEquals(Integer.valueOf(456), query1.getMaxValuesPerFacet());
         assertEquals("456", query1.get("maxValuesPerFacet"));
         Query query2 = Query.parse(query1.build());
         assertEquals(query1.getMaxValuesPerFacet(), query2.getMaxValuesPerFacet());
@@ -660,7 +660,7 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getMinimumAroundRadius());
         query1.setMinimumAroundRadius(1000);
-        assertEquals(new Integer(1000), query1.getMinimumAroundRadius());
+        assertEquals(Integer.valueOf(1000), query1.getMinimumAroundRadius());
         assertEquals("1000", query1.get("minimumAroundRadius"));
         Query query2 = Query.parse(query1.build());
         assertEquals(query1.getMinimumAroundRadius(), query2.getMinimumAroundRadius());

--- a/algoliasearch/src/test/java/com/algolia/search/saas/QueryTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/QueryTest.java
@@ -116,6 +116,7 @@ public class QueryTest extends RobolectricTestCase {
         assertNull(query1.getMinWordSizefor1Typo());
         query1.setMinWordSizefor1Typo(123);
         assertEquals(Integer.valueOf(123), query1.getMinWordSizefor1Typo());
+        assertEquals("123", query1.get("minWordSizefor1Typo"));
         Query query2 = Query.parse(query1.build());
         assertEquals(query1.getMinWordSizefor1Typo(), query2.getMinWordSizefor1Typo());
     }
@@ -126,6 +127,7 @@ public class QueryTest extends RobolectricTestCase {
         assertNull(query1.getMinWordSizefor2Typos());
         query1.setMinWordSizefor2Typos(456);
         assertEquals(Integer.valueOf(456), query1.getMinWordSizefor2Typos());
+        assertEquals("456", query1.get("minWordSizefor2Typos"));
         Query query2 = Query.parse(query1.build());
         assertEquals(query1.getMinWordSizefor2Typos(), query2.getMinWordSizefor2Typos());
     }
@@ -136,6 +138,7 @@ public class QueryTest extends RobolectricTestCase {
         assertNull(query1.getMinProximity());
         query1.setMinProximity(999);
         assertEquals(Integer.valueOf(999), query1.getMinProximity());
+        assertEquals("999", query1.get("minProximity"));
         Query query2 = Query.parse(query1.build());
         assertEquals(query1.getMinProximity(), query2.getMinProximity());
     }
@@ -146,11 +149,13 @@ public class QueryTest extends RobolectricTestCase {
         assertNull(query1.getGetRankingInfo());
         query1.setGetRankingInfo(true);
         assertEquals(Boolean.TRUE, query1.getGetRankingInfo());
+        assertEquals("true", query1.get("getRankingInfo"));
         Query query2 = Query.parse(query1.build());
         assertEquals(query1.getGetRankingInfo(), query2.getGetRankingInfo());
 
         query1.setGetRankingInfo(false);
         assertEquals(Boolean.FALSE, query1.getGetRankingInfo());
+        assertEquals("false", query1.get("getRankingInfo"));
         Query query3 = Query.parse(query1.build());
         assertEquals(query1.getGetRankingInfo(), query3.getGetRankingInfo());
     }
@@ -164,15 +169,18 @@ public class QueryTest extends RobolectricTestCase {
         // Boolean values
         query.setIgnorePlurals(true);
         assertEquals("A true boolean should enable ignorePlurals.", Boolean.TRUE, query.getIgnorePlurals().enabled);
+        assertEquals("A true boolean should be in ignorePlurals.", "true", query.get("ignorePlurals"));
         assertEquals("A true boolean should be built and parsed successfully.", query.getIgnorePlurals(), Query.parse(query.build()).getIgnorePlurals());
 
         query.setIgnorePlurals(false);
         assertEquals("A false boolean should disable ignorePlurals.", Boolean.FALSE, query.getIgnorePlurals().enabled);
+        assertEquals("A false boolean should should be in ignorePlurals.", "false", query.get("ignorePlurals"));
         assertEquals("A false boolean should be built and parsed successfully.", query.getIgnorePlurals(), Query.parse(query.build()).getIgnorePlurals());
 
         // List values
         query.setIgnorePlurals((List<String>) null);
         assertFalse("A null list value should disable ignorePlurals.", query.getIgnorePlurals().enabled);
+        assertEquals("A null list value should disable ignorePlurals.", "false", query.get("ignorePlurals"));
         assertEquals("A null list value should be built and parsed successfully.", query.getIgnorePlurals(), Query.parse(query.build()).getIgnorePlurals());
 
         query.setIgnorePlurals(new ArrayList<String>());
@@ -181,6 +189,7 @@ public class QueryTest extends RobolectricTestCase {
         ArrayList<String> languageCodes = new ArrayList<>(java.util.Arrays.asList("en", "fr"));
         query.setIgnorePlurals(languageCodes);
         assertTrue("Setting a non-empty list should enable ignorePlurals.", query.getIgnorePlurals().enabled);
+        assertEquals("Setting a non-empty list should be in ignorePlurals.", "en,fr", query.get("ignorePlurals"));
         assertNotNull("The language codes should not be null", query.getIgnorePlurals().languageCodes);
         assertEquals("Two language codes should be in ignorePlurals.", 2, query.getIgnorePlurals().languageCodes.size());
         assertTrue("The first language code should be in ignorePlurals", query.getIgnorePlurals().languageCodes.contains(languageCodes.get(0)));
@@ -189,16 +198,19 @@ public class QueryTest extends RobolectricTestCase {
         // String[] values
         query.setIgnorePlurals("");
         assertFalse("An empty string should disable ignorePlurals.", query.getIgnorePlurals().enabled);
+        assertEquals("An empty string should be in ignorePlurals.", "", query.get("ignorePlurals"));
         assertEquals("A empty string should be built and parsed successfully.", query.getIgnorePlurals(), Query.parse(query.build()).getIgnorePlurals());
 
         query.setIgnorePlurals("en");
         assertEquals("A single language code should enable ignorePlurals.", Boolean.TRUE, query.getIgnorePlurals().enabled);
+        assertEquals("A single language code should be in ignorePlurals.", "en", query.get("ignorePlurals"));
         assertEquals("A single language code should be built and parsed successfully.", query.getIgnorePlurals(), Query.parse(query.build()).getIgnorePlurals());
         assertEquals("One language code should be in ignorePlurals.", 1, query.getIgnorePlurals().languageCodes.size());
         assertTrue("The language code should be in ignorePlurals", query.getIgnorePlurals().languageCodes.contains("en"));
 
         query.setIgnorePlurals("en", "fr");
         assertEquals("Two language codes should enable ignorePlurals.", Boolean.TRUE, query.getIgnorePlurals().enabled);
+        assertEquals("Two language codes should be in ignorePlurals.", "en,fr", query.get("ignorePlurals"));
         assertEquals("Two language codes should be built and parsed successfully.", query.getIgnorePlurals(), Query.parse(query.build()).getIgnorePlurals());
         assertEquals("Two language codes should be in ignorePlurals.", 2, query.getIgnorePlurals().languageCodes.size());
         assertTrue("The first language code should be in ignorePlurals", query.getIgnorePlurals().languageCodes.contains("en"));
@@ -211,6 +223,7 @@ public class QueryTest extends RobolectricTestCase {
         assertNull(query1.getDistinct());
         query1.setDistinct(100);
         assertEquals(Integer.valueOf(100), query1.getDistinct());
+        assertEquals("100", query1.get("distinct"));
         Query query2 = Query.parse(query1.build());
         assertEquals(query1.getDistinct(), query2.getDistinct());
     }
@@ -221,6 +234,7 @@ public class QueryTest extends RobolectricTestCase {
         assertNull(query1.getPage());
         query1.setPage(0);
         assertEquals(Integer.valueOf(0), query1.getPage());
+        assertEquals("0", query1.get("page"));
         Query query2 = Query.parse(query1.build());
         assertEquals(query1.getPage(), query2.getPage());
     }
@@ -231,6 +245,7 @@ public class QueryTest extends RobolectricTestCase {
         assertNull(query1.getHitsPerPage());
         query1.setHitsPerPage(50);
         assertEquals(Integer.valueOf(50), query1.getHitsPerPage());
+        assertEquals("50", query1.get("hitsPerPage"));
         Query query2 = Query.parse(query1.build());
         assertEquals(query1.getHitsPerPage(), query2.getHitsPerPage());
     }
@@ -241,11 +256,13 @@ public class QueryTest extends RobolectricTestCase {
         assertNull(query1.getAllowTyposOnNumericTokens());
         query1.setAllowTyposOnNumericTokens(true);
         assertEquals(Boolean.TRUE, query1.getAllowTyposOnNumericTokens());
+        assertEquals("true", query1.get("allowTyposOnNumericTokens"));
         Query query2 = Query.parse(query1.build());
         assertEquals(query1.getAllowTyposOnNumericTokens(), query2.getAllowTyposOnNumericTokens());
 
         query1.setAllowTyposOnNumericTokens(false);
         assertEquals(Boolean.FALSE, query1.getAllowTyposOnNumericTokens());
+        assertEquals("false", query1.get("allowTyposOnNumericTokens"));
         Query query3 = Query.parse(query1.build());
         assertEquals(query1.getAllowTyposOnNumericTokens(), query3.getAllowTyposOnNumericTokens());
     }
@@ -256,6 +273,7 @@ public class QueryTest extends RobolectricTestCase {
         assertNull(query1.getAnalytics());
         query1.setAnalytics(true);
         assertEquals(Boolean.TRUE, query1.getAnalytics());
+        assertEquals("true", query1.get("analytics"));
         Query query2 = Query.parse(query1.build());
         assertEquals(query1.getAnalytics(), query2.getAnalytics());
     }
@@ -266,6 +284,7 @@ public class QueryTest extends RobolectricTestCase {
         assertNull(query1.getSynonyms());
         query1.setSynonyms(true);
         assertEquals(Boolean.TRUE, query1.getSynonyms());
+        assertEquals("true", query1.get("synonyms"));
         Query query2 = Query.parse(query1.build());
         assertEquals(query1.getSynonyms(), query2.getSynonyms());
     }
@@ -276,6 +295,7 @@ public class QueryTest extends RobolectricTestCase {
         assertNull(query1.getAttributesToHighlight());
         query1.setAttributesToHighlight("foo", "bar");
         assertArrayEquals(new String[]{ "foo", "bar" }, query1.getAttributesToHighlight());
+        assertEquals("[\"foo\",\"bar\"]", query1.get("attributesToHighlight"));
         Query query2 = Query.parse(query1.build());
         assertArrayEquals(query1.getAttributesToHighlight(), query2.getAttributesToHighlight());
     }
@@ -286,6 +306,7 @@ public class QueryTest extends RobolectricTestCase {
         assertNull(query1.getAttributesToRetrieve());
         query1.setAttributesToRetrieve("foo", "bar");
         assertArrayEquals(new String[]{ "foo", "bar" }, query1.getAttributesToRetrieve());
+        assertEquals("[\"foo\",\"bar\"]", query1.get("attributesToRetrieve"));
         Query query2 = Query.parse(query1.build());
         assertArrayEquals(query1.getAttributesToRetrieve(), query2.getAttributesToRetrieve());
     }
@@ -296,6 +317,7 @@ public class QueryTest extends RobolectricTestCase {
         assertNull(query1.getAttributesToSnippet());
         query1.setAttributesToSnippet("foo:3", "bar:7");
         assertArrayEquals(new String[]{ "foo:3", "bar:7" }, query1.getAttributesToSnippet());
+        assertEquals("[\"foo:3\",\"bar:7\"]", query1.get("attributesToSnippet"));
         Query query2 = Query.parse(query1.build());
         assertArrayEquals(query1.getAttributesToSnippet(), query2.getAttributesToSnippet());
     }
@@ -306,6 +328,7 @@ public class QueryTest extends RobolectricTestCase {
         assertNull(query1.getQuery());
         query1.setQuery("supercalifragilisticexpialidocious");
         assertEquals("supercalifragilisticexpialidocious", query1.getQuery());
+        assertEquals("supercalifragilisticexpialidocious", query1.get("query"));
         Query query2 = Query.parse(query1.build());
         assertEquals(query1.getQuery(), query2.getQuery());
     }
@@ -732,13 +755,15 @@ public class QueryTest extends RobolectricTestCase {
         assertNull("A new query should have a null aroundRadius.", query.getAroundRadius());
 
         query.setAroundRadius(VALUE);
-        assertEquals("After setting its aroundRadius to a given integer, we should return it from getAroundRadius.", VALUE, query.getAroundRadius());
+        assertEquals("After setting a query's aroundRadius to a given integer, we should return it from getAroundRadius.", VALUE, query.getAroundRadius());
+        assertEquals("After setting a query's aroundRadius to a given integer, it should be in aroundRadius.", String.valueOf(VALUE), query.get("aroundRadius"));
 
         String queryStr = query.build();
         assertTrue("The built query should contain 'aroundRadius=" + VALUE + "'.", queryStr.contains("aroundRadius=" + VALUE));
 
         query.setAroundRadius(Query.RADIUS_ALL);
-        assertEquals("After setting it to RADIUS_ALL, a query should have this aroundRadius value.", Integer.valueOf(Query.RADIUS_ALL), query.getAroundRadius());
+        assertEquals("After setting a query's aroundRadius to RADIUS_ALL, it should have this aroundRadius value.", Integer.valueOf(Query.RADIUS_ALL), query.getAroundRadius());
+        assertEquals("After setting a query's aroundRadius to RADIUS_ALL, its aroundRadius should be equal to \"all\".", "all", query.get("aroundRadius"));
 
         queryStr = query.build();
         assertTrue("The built query should contain 'aroundRadius=all', not _" + queryStr + "_.", queryStr.contains("aroundRadius=all"));

--- a/algoliasearch/src/test/java/com/algolia/search/saas/QueryTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/QueryTest.java
@@ -62,28 +62,26 @@ public class QueryTest extends RobolectricTestCase {
     @Test
     public void parse() {
         // Build the URL for a query.
-        Query query1 = new Query();
-        query1.set("foo", "bar");
-        query1.set("abc", "xyz");
-        String queryString = query1.build();
+        Query query = new Query();
+        query.set("foo", "bar");
+        query.set("abc", "xyz");
+        String queryString = query.build();
 
         // Parse the URL into another query.
-        Query query2 = Query.parse(queryString);
-        assertEquals(query1, query2);
+        assertEquals(query, Query.parse(queryString));
     }
 
     /** Test that non-ASCII and special characters are escaped. */
     @Test
     public void escape() {
-        Query query1 = new Query();
-        query1.set("accented", "éêèàôù");
-        query1.set("escaped", " %&=#+");
-        String queryString = query1.build();
+        Query query = new Query();
+        query.set("accented", "éêèàôù");
+        query.set("escaped", " %&=#+");
+        String queryString = query.build();
         assertEquals("accented=%C3%A9%C3%AA%C3%A8%C3%A0%C3%B4%C3%B9&escaped=%20%25%26%3D%23%2B", queryString);
 
         // Test parsing of escaped characters.
-        Query query2 = Query.parse(queryString);
-        assertEquals(query1, query2);
+        assertEquals(query, Query.parse(queryString));
     }
 
     // ----------------------------------------------------------------------
@@ -112,52 +110,47 @@ public class QueryTest extends RobolectricTestCase {
 
     @Test
     public void minWordSizefor1Typo() {
-        Query query1 = new Query();
-        assertNull(query1.getMinWordSizefor1Typo());
-        query1.setMinWordSizefor1Typo(123);
-        assertEquals(Integer.valueOf(123), query1.getMinWordSizefor1Typo());
-        assertEquals("123", query1.get("minWordSizefor1Typo"));
-        Query query2 = Query.parse(query1.build());
-        assertEquals(query1.getMinWordSizefor1Typo(), query2.getMinWordSizefor1Typo());
+        Query query = new Query();
+        assertNull(query.getMinWordSizefor1Typo());
+        query.setMinWordSizefor1Typo(123);
+        assertEquals(Integer.valueOf(123), query.getMinWordSizefor1Typo());
+        assertEquals("123", query.get("minWordSizefor1Typo"));
+        assertEquals(query.getMinWordSizefor1Typo(), Query.parse(query.build()).getMinWordSizefor1Typo());
     }
 
     @Test
     public void minWordSizefor2Typos() {
-        Query query1 = new Query();
-        assertNull(query1.getMinWordSizefor2Typos());
-        query1.setMinWordSizefor2Typos(456);
-        assertEquals(Integer.valueOf(456), query1.getMinWordSizefor2Typos());
-        assertEquals("456", query1.get("minWordSizefor2Typos"));
-        Query query2 = Query.parse(query1.build());
-        assertEquals(query1.getMinWordSizefor2Typos(), query2.getMinWordSizefor2Typos());
+        Query query = new Query();
+        assertNull(query.getMinWordSizefor2Typos());
+        query.setMinWordSizefor2Typos(456);
+        assertEquals(Integer.valueOf(456), query.getMinWordSizefor2Typos());
+        assertEquals("456", query.get("minWordSizefor2Typos"));
+        assertEquals(query.getMinWordSizefor2Typos(), Query.parse(query.build()).getMinWordSizefor2Typos());
     }
 
     @Test
     public void minProximity() {
-        Query query1 = new Query();
-        assertNull(query1.getMinProximity());
-        query1.setMinProximity(999);
-        assertEquals(Integer.valueOf(999), query1.getMinProximity());
-        assertEquals("999", query1.get("minProximity"));
-        Query query2 = Query.parse(query1.build());
-        assertEquals(query1.getMinProximity(), query2.getMinProximity());
+        Query query = new Query();
+        assertNull(query.getMinProximity());
+        query.setMinProximity(999);
+        assertEquals(Integer.valueOf(999), query.getMinProximity());
+        assertEquals("999", query.get("minProximity"));
+        assertEquals(query.getMinProximity(), Query.parse(query.build()).getMinProximity());
     }
 
     @Test
     public void getRankingInfo() {
-        Query query1 = new Query();
-        assertNull(query1.getGetRankingInfo());
-        query1.setGetRankingInfo(true);
-        assertEquals(Boolean.TRUE, query1.getGetRankingInfo());
-        assertEquals("true", query1.get("getRankingInfo"));
-        Query query2 = Query.parse(query1.build());
-        assertEquals(query1.getGetRankingInfo(), query2.getGetRankingInfo());
+        Query query = new Query();
+        assertNull(query.getGetRankingInfo());
+        query.setGetRankingInfo(true);
+        assertEquals(Boolean.TRUE, query.getGetRankingInfo());
+        assertEquals("true", query.get("getRankingInfo"));
+        assertEquals(query.getGetRankingInfo(), Query.parse(query.build()).getGetRankingInfo());
 
-        query1.setGetRankingInfo(false);
-        assertEquals(Boolean.FALSE, query1.getGetRankingInfo());
-        assertEquals("false", query1.get("getRankingInfo"));
-        Query query3 = Query.parse(query1.build());
-        assertEquals(query1.getGetRankingInfo(), query3.getGetRankingInfo());
+        query.setGetRankingInfo(false);
+        assertEquals(Boolean.FALSE, query.getGetRankingInfo());
+        assertEquals("false", query.get("getRankingInfo"));
+        assertEquals(query.getGetRankingInfo(), Query.parse(query.build()).getGetRankingInfo());
     }
 
     @Test
@@ -219,448 +212,412 @@ public class QueryTest extends RobolectricTestCase {
 
     @Test
     public void distinct() {
-        Query query1 = new Query();
-        assertNull(query1.getDistinct());
-        query1.setDistinct(100);
-        assertEquals(Integer.valueOf(100), query1.getDistinct());
-        assertEquals("100", query1.get("distinct"));
-        Query query2 = Query.parse(query1.build());
-        assertEquals(query1.getDistinct(), query2.getDistinct());
+        Query query = new Query();
+        assertNull(query.getDistinct());
+        query.setDistinct(100);
+        assertEquals(Integer.valueOf(100), query.getDistinct());
+        assertEquals("100", query.get("distinct"));
+        assertEquals(query.getDistinct(), Query.parse(query.build()).getDistinct());
     }
 
     @Test
     public void page() {
-        Query query1 = new Query();
-        assertNull(query1.getPage());
-        query1.setPage(0);
-        assertEquals(Integer.valueOf(0), query1.getPage());
-        assertEquals("0", query1.get("page"));
-        Query query2 = Query.parse(query1.build());
-        assertEquals(query1.getPage(), query2.getPage());
+        Query query = new Query();
+        assertNull(query.getPage());
+        query.setPage(0);
+        assertEquals(Integer.valueOf(0), query.getPage());
+        assertEquals("0", query.get("page"));
+        assertEquals(query.getPage(), Query.parse(query.build()).getPage());
     }
 
     @Test
     public void hitsPerPage() {
-        Query query1 = new Query();
-        assertNull(query1.getHitsPerPage());
-        query1.setHitsPerPage(50);
-        assertEquals(Integer.valueOf(50), query1.getHitsPerPage());
-        assertEquals("50", query1.get("hitsPerPage"));
-        Query query2 = Query.parse(query1.build());
-        assertEquals(query1.getHitsPerPage(), query2.getHitsPerPage());
+        Query query = new Query();
+        assertNull(query.getHitsPerPage());
+        query.setHitsPerPage(50);
+        assertEquals(Integer.valueOf(50), query.getHitsPerPage());
+        assertEquals("50", query.get("hitsPerPage"));
+        assertEquals(query.getHitsPerPage(), Query.parse(query.build()).getHitsPerPage());
     }
 
     @Test
     public void allowTyposOnNumericTokens() {
-        Query query1 = new Query();
-        assertNull(query1.getAllowTyposOnNumericTokens());
-        query1.setAllowTyposOnNumericTokens(true);
-        assertEquals(Boolean.TRUE, query1.getAllowTyposOnNumericTokens());
-        assertEquals("true", query1.get("allowTyposOnNumericTokens"));
-        Query query2 = Query.parse(query1.build());
-        assertEquals(query1.getAllowTyposOnNumericTokens(), query2.getAllowTyposOnNumericTokens());
+        Query query = new Query();
+        assertNull(query.getAllowTyposOnNumericTokens());
+        query.setAllowTyposOnNumericTokens(true);
+        assertEquals(Boolean.TRUE, query.getAllowTyposOnNumericTokens());
+        assertEquals("true", query.get("allowTyposOnNumericTokens"));
+        assertEquals(query.getAllowTyposOnNumericTokens(), Query.parse(query.build()).getAllowTyposOnNumericTokens());
 
-        query1.setAllowTyposOnNumericTokens(false);
-        assertEquals(Boolean.FALSE, query1.getAllowTyposOnNumericTokens());
-        assertEquals("false", query1.get("allowTyposOnNumericTokens"));
-        Query query3 = Query.parse(query1.build());
-        assertEquals(query1.getAllowTyposOnNumericTokens(), query3.getAllowTyposOnNumericTokens());
+        query.setAllowTyposOnNumericTokens(false);
+        assertEquals(Boolean.FALSE, query.getAllowTyposOnNumericTokens());
+        assertEquals("false", query.get("allowTyposOnNumericTokens"));
+        assertEquals(query.getAllowTyposOnNumericTokens(), Query.parse(query.build()).getAllowTyposOnNumericTokens());
     }
 
     @Test
     public void analytics() {
-        Query query1 = new Query();
-        assertNull(query1.getAnalytics());
-        query1.setAnalytics(true);
-        assertEquals(Boolean.TRUE, query1.getAnalytics());
-        assertEquals("true", query1.get("analytics"));
-        Query query2 = Query.parse(query1.build());
-        assertEquals(query1.getAnalytics(), query2.getAnalytics());
+        Query query = new Query();
+        assertNull(query.getAnalytics());
+        query.setAnalytics(true);
+        assertEquals(Boolean.TRUE, query.getAnalytics());
+        assertEquals("true", query.get("analytics"));
+        assertEquals(query.getAnalytics(), Query.parse(query.build()).getAnalytics());
     }
 
     @Test
     public void synonyms() {
-        Query query1 = new Query();
-        assertNull(query1.getSynonyms());
-        query1.setSynonyms(true);
-        assertEquals(Boolean.TRUE, query1.getSynonyms());
-        assertEquals("true", query1.get("synonyms"));
-        Query query2 = Query.parse(query1.build());
-        assertEquals(query1.getSynonyms(), query2.getSynonyms());
+        Query query = new Query();
+        assertNull(query.getSynonyms());
+        query.setSynonyms(true);
+        assertEquals(Boolean.TRUE, query.getSynonyms());
+        assertEquals("true", query.get("synonyms"));
+        assertEquals(query.getSynonyms(), Query.parse(query.build()).getSynonyms());
     }
 
     @Test
     public void attributesToHighlight() {
-        Query query1 = new Query();
-        assertNull(query1.getAttributesToHighlight());
-        query1.setAttributesToHighlight("foo", "bar");
-        assertArrayEquals(new String[]{ "foo", "bar" }, query1.getAttributesToHighlight());
-        assertEquals("[\"foo\",\"bar\"]", query1.get("attributesToHighlight"));
-        Query query2 = Query.parse(query1.build());
-        assertArrayEquals(query1.getAttributesToHighlight(), query2.getAttributesToHighlight());
+        Query query = new Query();
+        assertNull(query.getAttributesToHighlight());
+        query.setAttributesToHighlight("foo", "bar");
+        assertArrayEquals(new String[]{ "foo", "bar" }, query.getAttributesToHighlight());
+        assertEquals("[\"foo\",\"bar\"]", query.get("attributesToHighlight"));
+        assertArrayEquals(query.getAttributesToHighlight(), Query.parse(query.build()).getAttributesToHighlight());
     }
 
     @Test
     public void attributesToRetrieve() {
-        Query query1 = new Query();
-        assertNull(query1.getAttributesToRetrieve());
-        query1.setAttributesToRetrieve("foo", "bar");
-        assertArrayEquals(new String[]{ "foo", "bar" }, query1.getAttributesToRetrieve());
-        assertEquals("[\"foo\",\"bar\"]", query1.get("attributesToRetrieve"));
-        Query query2 = Query.parse(query1.build());
-        assertArrayEquals(query1.getAttributesToRetrieve(), query2.getAttributesToRetrieve());
+        Query query = new Query();
+        assertNull(query.getAttributesToRetrieve());
+        query.setAttributesToRetrieve("foo", "bar");
+        assertArrayEquals(new String[]{ "foo", "bar" }, query.getAttributesToRetrieve());
+        assertEquals("[\"foo\",\"bar\"]", query.get("attributesToRetrieve"));
+        assertArrayEquals(query.getAttributesToRetrieve(), Query.parse(query.build()).getAttributesToRetrieve());
     }
 
     @Test
     public void attributesToSnippet() {
-        Query query1 = new Query();
-        assertNull(query1.getAttributesToSnippet());
-        query1.setAttributesToSnippet("foo:3", "bar:7");
-        assertArrayEquals(new String[]{ "foo:3", "bar:7" }, query1.getAttributesToSnippet());
-        assertEquals("[\"foo:3\",\"bar:7\"]", query1.get("attributesToSnippet"));
-        Query query2 = Query.parse(query1.build());
-        assertArrayEquals(query1.getAttributesToSnippet(), query2.getAttributesToSnippet());
+        Query query = new Query();
+        assertNull(query.getAttributesToSnippet());
+        query.setAttributesToSnippet("foo:3", "bar:7");
+        assertArrayEquals(new String[]{ "foo:3", "bar:7" }, query.getAttributesToSnippet());
+        assertEquals("[\"foo:3\",\"bar:7\"]", query.get("attributesToSnippet"));
+        assertArrayEquals(query.getAttributesToSnippet(), Query.parse(query.build()).getAttributesToSnippet());
     }
 
     @Test
     public void query() {
-        Query query1 = new Query();
-        assertNull(query1.getQuery());
-        query1.setQuery("supercalifragilisticexpialidocious");
-        assertEquals("supercalifragilisticexpialidocious", query1.getQuery());
-        assertEquals("supercalifragilisticexpialidocious", query1.get("query"));
-        Query query2 = Query.parse(query1.build());
-        assertEquals(query1.getQuery(), query2.getQuery());
+        Query query = new Query();
+        assertNull(query.getQuery());
+        query.setQuery("supercalifragilisticexpialidocious");
+        assertEquals("supercalifragilisticexpialidocious", query.getQuery());
+        assertEquals("supercalifragilisticexpialidocious", query.get("query"));
+        assertEquals(query.getQuery(), Query.parse(query.build()).getQuery());
     }
 
     @Test
     public void queryType() {
-        Query query1 = new Query();
-        assertNull(query1.getQueryType());
+        Query query = new Query();
+        assertNull(query.getQueryType());
 
-        query1.setQueryType(Query.QueryType.PREFIX_ALL);
-        assertEquals(Query.QueryType.PREFIX_ALL, query1.getQueryType());
-        assertEquals("prefixAll", query1.get("queryType"));
-        Query query2 = Query.parse(query1.build());
-        assertEquals(query1.getQueryType(), query2.getQueryType());
+        query.setQueryType(Query.QueryType.PREFIX_ALL);
+        assertEquals(Query.QueryType.PREFIX_ALL, query.getQueryType());
+        assertEquals("prefixAll", query.get("queryType"));
+        assertEquals(query.getQueryType(), Query.parse(query.build()).getQueryType());
 
-        query1.setQueryType(Query.QueryType.PREFIX_LAST);
-        assertEquals(Query.QueryType.PREFIX_LAST, query1.getQueryType());
-        assertEquals("prefixLast", query1.get("queryType"));
-        query2 = Query.parse(query1.build());
-        assertEquals(query1.getQueryType(), query2.getQueryType());
+        query.setQueryType(Query.QueryType.PREFIX_LAST);
+        assertEquals(Query.QueryType.PREFIX_LAST, query.getQueryType());
+        assertEquals("prefixLast", query.get("queryType"));
+        assertEquals(query.getQueryType(), Query.parse(query.build()).getQueryType());
 
-        query1.setQueryType(Query.QueryType.PREFIX_NONE);
-        assertEquals(query1.getQueryType(), Query.QueryType.PREFIX_NONE);
-        assertEquals(query1.get("queryType"), "prefixNone");
-        query2 = Query.parse(query1.build());
-        assertEquals(query1.getQueryType(), query2.getQueryType());
+        query.setQueryType(Query.QueryType.PREFIX_NONE);
+        assertEquals(query.getQueryType(), Query.QueryType.PREFIX_NONE);
+        assertEquals(query.get("queryType"), "prefixNone");
+        assertEquals(query.getQueryType(), Query.parse(query.build()).getQueryType());
 
-        query1.set("queryType", "invalid");
-        assertNull(query1.getQueryType());
+        query.set("queryType", "invalid");
+        assertNull(query.getQueryType());
     }
 
     @Test
     public void removeWordsIfNoResults() {
-        Query query1 = new Query();
-        assertNull(query1.getRemoveWordsIfNoResults());
+        Query query = new Query();
+        assertNull(query.getRemoveWordsIfNoResults());
 
-        query1.setRemoveWordsIfNoResults(Query.RemoveWordsIfNoResults.ALL_OPTIONAL);
-        assertEquals(Query.RemoveWordsIfNoResults.ALL_OPTIONAL, query1.getRemoveWordsIfNoResults());
-        assertEquals("allOptional", query1.get("removeWordsIfNoResults"));
-        Query query2 = Query.parse(query1.build());
-        assertEquals(query1.getRemoveWordsIfNoResults(), query2.getRemoveWordsIfNoResults());
+        query.setRemoveWordsIfNoResults(Query.RemoveWordsIfNoResults.ALL_OPTIONAL);
+        assertEquals(Query.RemoveWordsIfNoResults.ALL_OPTIONAL, query.getRemoveWordsIfNoResults());
+        assertEquals("allOptional", query.get("removeWordsIfNoResults"));
+        assertEquals(query.getRemoveWordsIfNoResults(), Query.parse(query.build()).getRemoveWordsIfNoResults());
 
-        query1.setRemoveWordsIfNoResults(Query.RemoveWordsIfNoResults.FIRST_WORDS);
-        assertEquals(Query.RemoveWordsIfNoResults.FIRST_WORDS, query1.getRemoveWordsIfNoResults());
-        assertEquals("firstWords", query1.get("removeWordsIfNoResults"));
-        query2 = Query.parse(query1.build());
-        assertEquals(query1.getRemoveWordsIfNoResults(), query2.getRemoveWordsIfNoResults());
+        query.setRemoveWordsIfNoResults(Query.RemoveWordsIfNoResults.FIRST_WORDS);
+        assertEquals(Query.RemoveWordsIfNoResults.FIRST_WORDS, query.getRemoveWordsIfNoResults());
+        assertEquals("firstWords", query.get("removeWordsIfNoResults"));
+        assertEquals(query.getRemoveWordsIfNoResults(), Query.parse(query.build()).getRemoveWordsIfNoResults());
 
-        query1.setRemoveWordsIfNoResults(Query.RemoveWordsIfNoResults.LAST_WORDS);
-        assertEquals(Query.RemoveWordsIfNoResults.LAST_WORDS, query1.getRemoveWordsIfNoResults());
-        assertEquals("lastWords", query1.get("removeWordsIfNoResults"));
-        query2 = Query.parse(query1.build());
-        assertEquals(query1.getRemoveWordsIfNoResults(), query2.getRemoveWordsIfNoResults());
+        query.setRemoveWordsIfNoResults(Query.RemoveWordsIfNoResults.LAST_WORDS);
+        assertEquals(Query.RemoveWordsIfNoResults.LAST_WORDS, query.getRemoveWordsIfNoResults());
+        assertEquals("lastWords", query.get("removeWordsIfNoResults"));
+        assertEquals(query.getRemoveWordsIfNoResults(), Query.parse(query.build()).getRemoveWordsIfNoResults());
 
-        query1.setRemoveWordsIfNoResults(Query.RemoveWordsIfNoResults.NONE);
-        assertEquals(Query.RemoveWordsIfNoResults.NONE, query1.getRemoveWordsIfNoResults());
-        assertEquals("none", query1.get("removeWordsIfNoResults"));
-        query2 = Query.parse(query1.build());
-        assertEquals(query1.getRemoveWordsIfNoResults(), query2.getRemoveWordsIfNoResults());
+        query.setRemoveWordsIfNoResults(Query.RemoveWordsIfNoResults.NONE);
+        assertEquals(Query.RemoveWordsIfNoResults.NONE, query.getRemoveWordsIfNoResults());
+        assertEquals("none", query.get("removeWordsIfNoResults"));
+        assertEquals(query.getRemoveWordsIfNoResults(), Query.parse(query.build()).getRemoveWordsIfNoResults());
 
-        query1.set("removeWordsIfNoResults", "invalid");
-        assertNull(query1.getRemoveWordsIfNoResults());
+        query.set("removeWordsIfNoResults", "invalid");
+        assertNull(query.getRemoveWordsIfNoResults());
 
-        query1.set("removeWordsIfNoResults", "allOptional");
-        assertEquals(Query.RemoveWordsIfNoResults.ALL_OPTIONAL, query1.getRemoveWordsIfNoResults());
+        query.set("removeWordsIfNoResults", "allOptional");
+        assertEquals(Query.RemoveWordsIfNoResults.ALL_OPTIONAL, query.getRemoveWordsIfNoResults());
     }
 
     @Test
     public void typoTolerance() {
-        Query query1 = new Query();
-        assertNull(query1.getTypoTolerance());
+        Query query = new Query();
+        assertNull(query.getTypoTolerance());
 
-        query1.setTypoTolerance(Query.TypoTolerance.TRUE);
-        assertEquals(Query.TypoTolerance.TRUE, query1.getTypoTolerance());
-        assertEquals("true", query1.get("typoTolerance"));
-        Query query2 = Query.parse(query1.build());
-        assertEquals(query1.getTypoTolerance(), query2.getTypoTolerance());
+        query.setTypoTolerance(Query.TypoTolerance.TRUE);
+        assertEquals(Query.TypoTolerance.TRUE, query.getTypoTolerance());
+        assertEquals("true", query.get("typoTolerance"));
+        assertEquals(query.getTypoTolerance(), Query.parse(query.build()).getTypoTolerance());
 
-        query1.setTypoTolerance(Query.TypoTolerance.FALSE);
-        assertEquals(Query.TypoTolerance.FALSE, query1.getTypoTolerance());
-        assertEquals("false", query1.get("typoTolerance"));
-        query2 = Query.parse(query1.build());
-        assertEquals(query1.getTypoTolerance(), query2.getTypoTolerance());
+        query.setTypoTolerance(Query.TypoTolerance.FALSE);
+        assertEquals(Query.TypoTolerance.FALSE, query.getTypoTolerance());
+        assertEquals("false", query.get("typoTolerance"));
+        assertEquals(query.getTypoTolerance(), Query.parse(query.build()).getTypoTolerance());
 
-        query1.setTypoTolerance(Query.TypoTolerance.MIN);
-        assertEquals(Query.TypoTolerance.MIN, query1.getTypoTolerance());
-        assertEquals("min", query1.get("typoTolerance"));
-        query2 = Query.parse(query1.build());
-        assertEquals(query1.getTypoTolerance(), query2.getTypoTolerance());
+        query.setTypoTolerance(Query.TypoTolerance.MIN);
+        assertEquals(Query.TypoTolerance.MIN, query.getTypoTolerance());
+        assertEquals("min", query.get("typoTolerance"));
+        assertEquals(query.getTypoTolerance(), Query.parse(query.build()).getTypoTolerance());
 
-        query1.setTypoTolerance(Query.TypoTolerance.STRICT);
-        assertEquals(Query.TypoTolerance.STRICT, query1.getTypoTolerance());
-        assertEquals("strict", query1.get("typoTolerance"));
-        query2 = Query.parse(query1.build());
-        assertEquals(query1.getTypoTolerance(), query2.getTypoTolerance());
+        query.setTypoTolerance(Query.TypoTolerance.STRICT);
+        assertEquals(Query.TypoTolerance.STRICT, query.getTypoTolerance());
+        assertEquals("strict", query.get("typoTolerance"));
+        assertEquals(query.getTypoTolerance(), Query.parse(query.build()).getTypoTolerance());
 
-        query1.set("typoTolerance", "invalid");
-        assertNull(query1.getTypoTolerance());
+        query.set("typoTolerance", "invalid");
+        assertNull(query.getTypoTolerance());
 
-        query1.set("typoTolerance", "true");
-        assertEquals(Query.TypoTolerance.TRUE, query1.getTypoTolerance());
+        query.set("typoTolerance", "true");
+        assertEquals(Query.TypoTolerance.TRUE, query.getTypoTolerance());
     }
 
     @Test
     public void facets() {
-        Query query1 = new Query();
-        assertNull(query1.getFacets());
-        query1.setFacets("foo", "bar");
-        assertArrayEquals(new String[]{ "foo", "bar" }, query1.getFacets());
-        assertEquals("[\"foo\",\"bar\"]", query1.get("facets"));
-        Query query2 = Query.parse(query1.build());
-        assertArrayEquals(query1.getFacets(), query2.getFacets());
+        Query query = new Query();
+        assertNull(query.getFacets());
+        query.setFacets("foo", "bar");
+        assertArrayEquals(new String[]{ "foo", "bar" }, query.getFacets());
+        assertEquals("[\"foo\",\"bar\"]", query.get("facets"));
+        Query query2 = Query.parse(query.build());
+        assertArrayEquals(query.getFacets(), query2.getFacets());
     }
 
     @Test
     public void optionalWords() {
-        Query query1 = new Query();
-        assertNull(query1.getOptionalWords());
-        query1.setOptionalWords("foo", "bar");
-        assertArrayEquals(new String[]{ "foo", "bar" }, query1.getOptionalWords());
-        assertEquals("[\"foo\",\"bar\"]", query1.get("optionalWords"));
-        Query query2 = Query.parse(query1.build());
-        assertArrayEquals(query1.getOptionalWords(), query2.getOptionalWords());
+        Query query = new Query();
+        assertNull(query.getOptionalWords());
+        query.setOptionalWords("foo", "bar");
+        assertArrayEquals(new String[]{ "foo", "bar" }, query.getOptionalWords());
+        assertEquals("[\"foo\",\"bar\"]", query.get("optionalWords"));
+        assertArrayEquals(query.getOptionalWords(), Query.parse(query.build()).getOptionalWords());
     }
 
     @Test
     public void restrictSearchableAttributes() {
-        Query query1 = new Query();
-        assertNull(query1.getRestrictSearchableAttributes());
-        query1.setRestrictSearchableAttributes("foo", "bar");
-        assertArrayEquals(new String[]{ "foo", "bar" }, query1.getRestrictSearchableAttributes());
-        assertEquals("[\"foo\",\"bar\"]", query1.get("restrictSearchableAttributes"));
-        Query query2 = Query.parse(query1.build());
-        assertArrayEquals(query1.getRestrictSearchableAttributes(), query2.getRestrictSearchableAttributes());
+        Query query = new Query();
+        assertNull(query.getRestrictSearchableAttributes());
+        query.setRestrictSearchableAttributes("foo", "bar");
+        assertArrayEquals(new String[]{ "foo", "bar" }, query.getRestrictSearchableAttributes());
+        assertEquals("[\"foo\",\"bar\"]", query.get("restrictSearchableAttributes"));
+        assertArrayEquals(query.getRestrictSearchableAttributes(), Query.parse(query.build()).getRestrictSearchableAttributes());
     }
 
     @Test
     public void highlightPreTag() {
-        Query query1 = new Query();
-        assertNull(query1.getHighlightPreTag());
-        query1.setHighlightPreTag("<PRE[");
-        assertEquals("<PRE[", query1.getHighlightPreTag());
-        assertEquals("<PRE[", query1.get("highlightPreTag"));
-        Query query2 = Query.parse(query1.build());
-        assertEquals(query1.getHighlightPreTag(), query2.getHighlightPreTag());
+        Query query = new Query();
+        assertNull(query.getHighlightPreTag());
+        query.setHighlightPreTag("<PRE[");
+        assertEquals("<PRE[", query.getHighlightPreTag());
+        assertEquals("<PRE[", query.get("highlightPreTag"));
+        assertEquals(query.getHighlightPreTag(), Query.parse(query.build()).getHighlightPreTag());
     }
 
     @Test
     public void highlightPostTag() {
-        Query query1 = new Query();
-        assertNull(query1.getHighlightPostTag());
-        query1.setHighlightPostTag("]POST>");
-        assertEquals("]POST>", query1.getHighlightPostTag());
-        assertEquals("]POST>", query1.get("highlightPostTag"));
-        Query query2 = Query.parse(query1.build());
-        assertEquals(query1.getHighlightPostTag(), query2.getHighlightPostTag());
+        Query query = new Query();
+        assertNull(query.getHighlightPostTag());
+        query.setHighlightPostTag("]POST>");
+        assertEquals("]POST>", query.getHighlightPostTag());
+        assertEquals("]POST>", query.get("highlightPostTag"));
+        assertEquals(query.getHighlightPostTag(), Query.parse(query.build()).getHighlightPostTag());
     }
 
     @Test
     public void snippetEllipsisText() {
-        Query query1 = new Query();
-        assertNull(query1.getSnippetEllipsisText());
-        query1.setSnippetEllipsisText("…");
-        assertEquals("…", query1.getSnippetEllipsisText());
-        assertEquals("…", query1.get("snippetEllipsisText"));
-        Query query2 = Query.parse(query1.build());
-        assertEquals(query1.getSnippetEllipsisText(), query2.getSnippetEllipsisText());
+        Query query = new Query();
+        assertNull(query.getSnippetEllipsisText());
+        query.setSnippetEllipsisText("…");
+        assertEquals("…", query.getSnippetEllipsisText());
+        assertEquals("…", query.get("snippetEllipsisText"));
+        Query query2 = Query.parse(query.build());
+        assertEquals(query.getSnippetEllipsisText(), query2.getSnippetEllipsisText());
     }
 
     @Test
     public void analyticsTags() {
-        Query query1 = new Query();
-        assertNull(query1.getAnalyticsTags());
-        query1.setAnalyticsTags("foo", "bar");
-        assertArrayEquals(new String[]{ "foo", "bar" }, query1.getAnalyticsTags());
-        assertEquals("[\"foo\",\"bar\"]", query1.get("analyticsTags"));
-        Query query2 = Query.parse(query1.build());
-        assertArrayEquals(query1.getAnalyticsTags(), query2.getAnalyticsTags());
+        Query query = new Query();
+        assertNull(query.getAnalyticsTags());
+        query.setAnalyticsTags("foo", "bar");
+        assertArrayEquals(new String[]{ "foo", "bar" }, query.getAnalyticsTags());
+        assertEquals("[\"foo\",\"bar\"]", query.get("analyticsTags"));
+        Query query2 = Query.parse(query.build());
+        assertArrayEquals(query.getAnalyticsTags(), query2.getAnalyticsTags());
     }
 
     @Test
     public void disableTypoToleranceOnAttributes() {
-        Query query1 = new Query();
-        assertNull(query1.getDisableTypoToleranceOnAttributes());
-        query1.setDisableTypoToleranceOnAttributes("foo", "bar");
-        assertArrayEquals(new String[]{ "foo", "bar" }, query1.getDisableTypoToleranceOnAttributes());
-        assertEquals("[\"foo\",\"bar\"]", query1.get("disableTypoToleranceOnAttributes"));
-        Query query2 = Query.parse(query1.build());
-        assertArrayEquals(query1.getDisableTypoToleranceOnAttributes(), query2.getDisableTypoToleranceOnAttributes());
+        Query query = new Query();
+        assertNull(query.getDisableTypoToleranceOnAttributes());
+        query.setDisableTypoToleranceOnAttributes("foo", "bar");
+        assertArrayEquals(new String[]{ "foo", "bar" }, query.getDisableTypoToleranceOnAttributes());
+        assertEquals("[\"foo\",\"bar\"]", query.get("disableTypoToleranceOnAttributes"));
+        Query query2 = Query.parse(query.build());
+        assertArrayEquals(query.getDisableTypoToleranceOnAttributes(), query2.getDisableTypoToleranceOnAttributes());
     }
 
     @Test
     public void aroundPrecision() {
-        Query query1 = new Query();
-        assertNull(query1.getAroundPrecision());
-        query1.setAroundPrecision(12345);
-        assertEquals(Integer.valueOf(12345), query1.getAroundPrecision());
-        assertEquals("12345", query1.get("aroundPrecision"));
-        Query query2 = Query.parse(query1.build());
-        assertEquals(query1.getAroundPrecision(), query2.getAroundPrecision());
+        Query query = new Query();
+        assertNull(query.getAroundPrecision());
+        query.setAroundPrecision(12345);
+        assertEquals(Integer.valueOf(12345), query.getAroundPrecision());
+        assertEquals("12345", query.get("aroundPrecision"));
+        Query query2 = Query.parse(query.build());
+        assertEquals(query.getAroundPrecision(), query2.getAroundPrecision());
     }
 
     @Test
     public void aroundRadius() {
-        Query query1 = new Query();
-        assertNull(query1.getAroundRadius());
-        query1.setAroundRadius(987);
-        assertEquals(Integer.valueOf(987), query1.getAroundRadius());
-        assertEquals("987", query1.get("aroundRadius"));
-        Query query2 = Query.parse(query1.build());
-        assertEquals(query1.getAroundRadius(), query2.getAroundRadius());
+        Query query = new Query();
+        assertNull(query.getAroundRadius());
+        query.setAroundRadius(987);
+        assertEquals(Integer.valueOf(987), query.getAroundRadius());
+        assertEquals("987", query.get("aroundRadius"));
+        Query query2 = Query.parse(query.build());
+        assertEquals(query.getAroundRadius(), query2.getAroundRadius());
     }
 
     @Test
     public void aroundLatLngViaIP() {
-        Query query1 = new Query();
-        assertNull(query1.getAroundLatLngViaIP());
-        query1.setAroundLatLngViaIP(true);
-        assertEquals(Boolean.TRUE, query1.getAroundLatLngViaIP());
-        assertEquals("true", query1.get("aroundLatLngViaIP"));
-        Query query2 = Query.parse(query1.build());
-        assertEquals(query1.getAroundLatLngViaIP(), query2.getAroundLatLngViaIP());
+        Query query = new Query();
+        assertNull(query.getAroundLatLngViaIP());
+        query.setAroundLatLngViaIP(true);
+        assertEquals(Boolean.TRUE, query.getAroundLatLngViaIP());
+        assertEquals("true", query.get("aroundLatLngViaIP"));
+        assertEquals(query.getAroundLatLngViaIP(), Query.parse(query.build()).getAroundLatLngViaIP());
     }
 
     @Test
     public void aroundLatLng() {
-        Query query1 = new Query();
-        assertNull(query1.getAroundLatLng());
-        query1.setAroundLatLng(new Query.LatLng(89.76, -123.45));
-        assertEquals(new Query.LatLng(89.76, -123.45), query1.getAroundLatLng());
-        assertEquals("89.76,-123.45", query1.get("aroundLatLng"));
-        Query query2 = Query.parse(query1.build());
-        assertEquals(query1.getAroundLatLng(), query2.getAroundLatLng());
+        Query query = new Query();
+        assertNull(query.getAroundLatLng());
+        query.setAroundLatLng(new Query.LatLng(89.76, -123.45));
+        assertEquals(new Query.LatLng(89.76, -123.45), query.getAroundLatLng());
+        assertEquals("89.76,-123.45", query.get("aroundLatLng"));
+        assertEquals(query.getAroundLatLng(), Query.parse(query.build()).getAroundLatLng());
     }
 
     @Test
     public void insideBoundingBox() {
-        Query query1 = new Query();
-        assertNull(query1.getInsideBoundingBox());
+        Query query = new Query();
+        assertNull(query.getInsideBoundingBox());
         final Query.GeoRect box1 = new Query.GeoRect(new Query.LatLng(11.111111, 22.222222), new Query.LatLng(33.333333, 44.444444));
-        query1.setInsideBoundingBox(box1);
-        assertArrayEquals(new Query.GeoRect[]{ box1 }, query1.getInsideBoundingBox());
-        assertEquals("11.111111,22.222222,33.333333,44.444444", query1.get("insideBoundingBox"));
-        Query query2 = Query.parse(query1.build());
-        assertArrayEquals(query1.getInsideBoundingBox(), query2.getInsideBoundingBox());
+        query.setInsideBoundingBox(box1);
+        assertArrayEquals(new Query.GeoRect[]{ box1 }, query.getInsideBoundingBox());
+        assertEquals("11.111111,22.222222,33.333333,44.444444", query.get("insideBoundingBox"));
+        assertArrayEquals(query.getInsideBoundingBox(), Query.parse(query.build()).getInsideBoundingBox());
 
         final Query.GeoRect box2 = new Query.GeoRect(new Query.LatLng(-55.555555, -66.666666), new Query.LatLng(-77.777777, -88.888888));
         final Query.GeoRect[] boxes = { box1, box2 };
-        query1.setInsideBoundingBox(boxes);
-        assertArrayEquals(boxes, query1.getInsideBoundingBox());
-        assertEquals("11.111111,22.222222,33.333333,44.444444,-55.555555,-66.666666,-77.777777,-88.888888", query1.get("insideBoundingBox"));
-        query2 = Query.parse(query1.build());
-        assertArrayEquals(query1.getInsideBoundingBox(), query2.getInsideBoundingBox());
+        query.setInsideBoundingBox(boxes);
+        assertArrayEquals(boxes, query.getInsideBoundingBox());
+        assertEquals("11.111111,22.222222,33.333333,44.444444,-55.555555,-66.666666,-77.777777,-88.888888", query.get("insideBoundingBox"));
+        assertArrayEquals(query.getInsideBoundingBox(), Query.parse(query.build()).getInsideBoundingBox());
     }
 
     @Test
     public void insidePolygon() {
-        Query query1 = new Query();
-        assertNull(query1.getInsidePolygon());
+        Query query = new Query();
+        assertNull(query.getInsidePolygon());
         final Query.LatLng[] box = { new Query.LatLng(11.111111, 22.222222), new Query.LatLng(33.333333, 44.444444), new Query.LatLng(-55.555555, -66.666666) };
-        query1.setInsidePolygon(box);
-        assertArrayEquals(box, query1.getInsidePolygon());
-        assertEquals("11.111111,22.222222,33.333333,44.444444,-55.555555,-66.666666", query1.get("insidePolygon"));
-        Query query2 = Query.parse(query1.build());
-        assertArrayEquals(query1.getInsidePolygon(), query2.getInsidePolygon());
+        query.setInsidePolygon(box);
+        assertArrayEquals(box, query.getInsidePolygon());
+        assertEquals("11.111111,22.222222,33.333333,44.444444,-55.555555,-66.666666", query.get("insidePolygon"));
+        assertArrayEquals(query.getInsidePolygon(), Query.parse(query.build()).getInsidePolygon());
     }
 
     @Test
     public void tagFilters() throws JSONException {
         final JSONArray VALUE = new JSONArray("[\"tag1\", [\"tag2\", \"tag3\"]]");
-        Query query1 = new Query();
-        assertNull(query1.getTagFilters());
-        query1.setTagFilters(VALUE);
-        assertEquals(VALUE, query1.getTagFilters());
-        assertEquals("[\"tag1\",[\"tag2\",\"tag3\"]]", query1.get("tagFilters"));
-        Query query2 = Query.parse(query1.build());
-        assertEquals(query1.getTagFilters(), query2.getTagFilters());
+        Query query = new Query();
+        assertNull(query.getTagFilters());
+        query.setTagFilters(VALUE);
+        assertEquals(VALUE, query.getTagFilters());
+        assertEquals("[\"tag1\",[\"tag2\",\"tag3\"]]", query.get("tagFilters"));
+        assertEquals(query.getTagFilters(), Query.parse(query.build()).getTagFilters());
     }
 
     @Test
     public void facetFilters() throws JSONException {
         final JSONArray VALUE = new JSONArray("[[\"category:Book\", \"category:Movie\"], \"author:John Doe\"]");
-        Query query1 = new Query();
-        assertNull(query1.getFacetFilters());
-        query1.setFacetFilters(VALUE);
-        assertEquals(VALUE, query1.getFacetFilters());
-        assertEquals("[[\"category:Book\",\"category:Movie\"],\"author:John Doe\"]", query1.get("facetFilters"));
-        Query query2 = Query.parse(query1.build());
-        assertEquals(query1.getFacetFilters(), query2.getFacetFilters());
+        Query query = new Query();
+        assertNull(query.getFacetFilters());
+        query.setFacetFilters(VALUE);
+        assertEquals(VALUE, query.getFacetFilters());
+        assertEquals("[[\"category:Book\",\"category:Movie\"],\"author:John Doe\"]", query.get("facetFilters"));
+        assertEquals(query.getFacetFilters(), Query.parse(query.build()).getFacetFilters());
     }
 
     @Test
     public void advancedSyntax() {
-        Query query1 = new Query();
-        assertNull(query1.getAdvancedSyntax());
-        query1.setAdvancedSyntax(true);
-        assertEquals(Boolean.TRUE, query1.getAdvancedSyntax());
-        assertEquals("true", query1.get("advancedSyntax"));
-        Query query2 = Query.parse(query1.build());
-        assertEquals(query1.getAdvancedSyntax(), query2.getAdvancedSyntax());
+        Query query = new Query();
+        assertNull(query.getAdvancedSyntax());
+        query.setAdvancedSyntax(true);
+        assertEquals(Boolean.TRUE, query.getAdvancedSyntax());
+        assertEquals("true", query.get("advancedSyntax"));
+        assertEquals(query.getAdvancedSyntax(), Query.parse(query.build()).getAdvancedSyntax());
     }
 
     @Test
     public void removeStopWordsBoolean() throws Exception {
-        Query query1 = new Query();
-        assertNull(query1.getRemoveStopWords());
-        query1.setRemoveStopWords(true);
-        assertEquals(Boolean.TRUE, query1.getRemoveStopWords());
-        assertEquals("true", query1.get("removeStopWords"));
-        Query query2 = Query.parse(query1.build());
-        assertEquals(query1.getRemoveStopWords(), query2.getRemoveStopWords());
+        Query query = new Query();
+        assertNull(query.getRemoveStopWords());
+        query.setRemoveStopWords(true);
+        assertEquals(Boolean.TRUE, query.getRemoveStopWords());
+        assertEquals("true", query.get("removeStopWords"));
+        assertEquals(query.getRemoveStopWords(), Query.parse(query.build()).getRemoveStopWords());
     }
 
     @Test
     public void removeStopWordsString() throws Exception {
-        Query query1 = new Query();
-        assertNull(query1.getRemoveStopWords());
+        Query query = new Query();
+        assertNull(query.getRemoveStopWords());
 
-        query1.setRemoveStopWords("fr,en");
-        final Object[] removeStopWords = (Object[]) query1.getRemoveStopWords();
+        query.setRemoveStopWords("fr,en");
+        final Object[] removeStopWords = (Object[]) query.getRemoveStopWords();
         assertArrayEquals(new String[]{"fr", "en"}, removeStopWords);
-        assertEquals("fr,en", query1.get("removeStopWords"));
+        assertEquals("fr,en", query.get("removeStopWords"));
 
-        Query query2 = Query.parse(query1.build());
-        assertArrayEquals((Object[]) query1.getRemoveStopWords(), (Object[]) query2.getRemoveStopWords());
+        assertArrayEquals((Object[]) query.getRemoveStopWords(), (Object[]) Query.parse(query.build()).getRemoveStopWords());
     }
 
     @Test
     public void removeStopWordsInvalidClass() throws Exception {
-        Query query1 = new Query();
+        Query query = new Query();
         try {
-            query1.setRemoveStopWords(42);
+            query.setRemoveStopWords(42);
         } catch (AlgoliaException ignored) {
             return; //pass
         }
@@ -669,48 +626,44 @@ public class QueryTest extends RobolectricTestCase {
 
     @Test
     public void maxValuesPerFacet() {
-        Query query1 = new Query();
-        assertNull(query1.getMaxValuesPerFacet());
-        query1.setMaxValuesPerFacet(456);
-        assertEquals(Integer.valueOf(456), query1.getMaxValuesPerFacet());
-        assertEquals("456", query1.get("maxValuesPerFacet"));
-        Query query2 = Query.parse(query1.build());
-        assertEquals(query1.getMaxValuesPerFacet(), query2.getMaxValuesPerFacet());
+        Query query = new Query();
+        assertNull(query.getMaxValuesPerFacet());
+        query.setMaxValuesPerFacet(456);
+        assertEquals(Integer.valueOf(456), query.getMaxValuesPerFacet());
+        assertEquals("456", query.get("maxValuesPerFacet"));
+        assertEquals(query.getMaxValuesPerFacet(), Query.parse(query.build()).getMaxValuesPerFacet());
     }
 
     @Test
     public void minimumAroundRadius() {
-        Query query1 = new Query();
-        assertNull(query1.getMinimumAroundRadius());
-        query1.setMinimumAroundRadius(1000);
-        assertEquals(Integer.valueOf(1000), query1.getMinimumAroundRadius());
-        assertEquals("1000", query1.get("minimumAroundRadius"));
-        Query query2 = Query.parse(query1.build());
-        assertEquals(query1.getMinimumAroundRadius(), query2.getMinimumAroundRadius());
+        Query query = new Query();
+        assertNull(query.getMinimumAroundRadius());
+        query.setMinimumAroundRadius(1000);
+        assertEquals(Integer.valueOf(1000), query.getMinimumAroundRadius());
+        assertEquals("1000", query.get("minimumAroundRadius"));
+        assertEquals(query.getMinimumAroundRadius(), Query.parse(query.build()).getMinimumAroundRadius());
     }
 
     @Test
     public void numericFilters() throws JSONException {
         final JSONArray VALUE = new JSONArray("[\"code=1\", [\"price:0 to 10\", \"price:1000 to 2000\"]]");
-        Query query1 = new Query();
-        assertNull(query1.getNumericFilters());
-        query1.setNumericFilters(VALUE);
-        assertEquals(VALUE, query1.getNumericFilters());
-        assertEquals("[\"code=1\",[\"price:0 to 10\",\"price:1000 to 2000\"]]", query1.get("numericFilters"));
-        Query query2 = Query.parse(query1.build());
-        assertEquals(query1.getNumericFilters(), query2.getNumericFilters());
+        Query query = new Query();
+        assertNull(query.getNumericFilters());
+        query.setNumericFilters(VALUE);
+        assertEquals(VALUE, query.getNumericFilters());
+        assertEquals("[\"code=1\",[\"price:0 to 10\",\"price:1000 to 2000\"]]", query.get("numericFilters"));
+        assertEquals(query.getNumericFilters(), Query.parse(query.build()).getNumericFilters());
     }
 
     @Test
     public void filters() {
         final String VALUE = "available=1 AND (category:Book OR NOT category:Ebook) AND publication_date: 1441745506 TO 1441755506 AND inStock > 0 AND author:\"John Doe\"";
-        Query query1 = new Query();
-        assertNull(query1.getFilters());
-        query1.setFilters(VALUE);
-        assertEquals(VALUE, query1.getFilters());
-        assertEquals(VALUE, query1.get("filters"));
-        Query query2 = Query.parse(query1.build());
-        assertEquals(query1.getFilters(), query2.getFilters());
+        Query query = new Query();
+        assertNull(query.getFilters());
+        query.setFilters(VALUE);
+        assertEquals(VALUE, query.getFilters());
+        assertEquals(VALUE, query.get("filters"));
+        assertEquals(query.getFilters(), Query.parse(query.build()).getFilters());
     }
 
     @Test
@@ -722,8 +675,7 @@ public class QueryTest extends RobolectricTestCase {
         query.setExactOnSingleWordQuery(VALUE);
         assertEquals(VALUE, query.getExactOnSingleWordQuery());
         assertEquals("attribute", query.get("exactOnSingleWordQuery"));
-        Query query2 = Query.parse(query.build());
-        assertEquals(query.getExactOnSingleWordQuery(), query2.getExactOnSingleWordQuery());
+        assertEquals(query.getExactOnSingleWordQuery(), Query.parse(query.build()).getExactOnSingleWordQuery());
     }
 
     @Test
@@ -744,8 +696,7 @@ public class QueryTest extends RobolectricTestCase {
 
         assertEquals("ignorePlurals,multiWordsSynonym", query.get("alternativesAsExact"));
 
-        Query query2 = Query.parse(query.build());
-        assertEquals(query.getExactOnSingleWordQuery(), query2.getExactOnSingleWordQuery());
+        assertEquals(query.getExactOnSingleWordQuery(), Query.parse(query.build()).getExactOnSingleWordQuery());
     }
 
     @Test
@@ -767,7 +718,6 @@ public class QueryTest extends RobolectricTestCase {
 
         queryStr = query.build();
         assertTrue("The built query should contain 'aroundRadius=all', not _" + queryStr + "_.", queryStr.contains("aroundRadius=all"));
-        Query query2 = Query.parse(query.build());
-        assertEquals("The built query should be parsed and built successfully.", query.getAroundRadius(), query2.getAroundRadius());
+        assertEquals("The built query should be parsed and built successfully.", query.getAroundRadius(), Query.parse(query.build()).getAroundRadius());
     }
 }

--- a/algoliasearch/src/test/java/com/algolia/search/saas/QueryTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/QueryTest.java
@@ -49,7 +49,7 @@ public class QueryTest extends RobolectricTestCase {
 
     /** Test serializing a query into a URL query string. */
     @Test
-    public void testBuild() {
+    public void build() {
         Query query = new Query();
         query.set("c", "C");
         query.set("b", "B");
@@ -60,7 +60,7 @@ public class QueryTest extends RobolectricTestCase {
 
     /** Test parsing a query from a URL query string. */
     @Test
-    public void testParse() {
+    public void parse() {
         // Build the URL for a query.
         Query query1 = new Query();
         query1.set("foo", "bar");
@@ -74,7 +74,7 @@ public class QueryTest extends RobolectricTestCase {
 
     /** Test that non-ASCII and special characters are escaped. */
     @Test
-    public void testEscape() {
+    public void escape() {
         Query query1 = new Query();
         query1.set("accented", "éêèàôù");
         query1.set("escaped", " %&=#+");
@@ -92,7 +92,7 @@ public class QueryTest extends RobolectricTestCase {
 
     /** Test low-level accessors. */
     @Test
-    public void testGetSet() {
+    public void getSet() {
         Query query = new Query();
 
         // Test accessors.
@@ -111,7 +111,7 @@ public class QueryTest extends RobolectricTestCase {
     // ----------------------------------------------------------------------
 
     @Test
-    public void test_minWordSizefor1Typo() {
+    public void minWordSizefor1Typo() {
         Query query1 = new Query();
         assertNull(query1.getMinWordSizefor1Typo());
         query1.setMinWordSizefor1Typo(123);
@@ -121,7 +121,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_minWordSizefor2Typos() {
+    public void minWordSizefor2Typos() {
         Query query1 = new Query();
         assertNull(query1.getMinWordSizefor2Typos());
         query1.setMinWordSizefor2Typos(456);
@@ -131,7 +131,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_minProximity() {
+    public void minProximity() {
         Query query1 = new Query();
         assertNull(query1.getMinProximity());
         query1.setMinProximity(999);
@@ -141,7 +141,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_getRankingInfo() {
+    public void getRankingInfo() {
         Query query1 = new Query();
         assertNull(query1.getGetRankingInfo());
         query1.setGetRankingInfo(true);
@@ -156,7 +156,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_ignorePlurals() {
+    public void ignorePlurals() {
         // No value
         Query query = new Query();
         assertFalse("By default, ignorePlurals should be disabled.", query.getIgnorePlurals().enabled);
@@ -206,7 +206,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_distinct() {
+    public void distinct() {
         Query query1 = new Query();
         assertNull(query1.getDistinct());
         query1.setDistinct(100);
@@ -216,7 +216,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_page() {
+    public void page() {
         Query query1 = new Query();
         assertNull(query1.getPage());
         query1.setPage(0);
@@ -226,7 +226,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_hitsPerPage() {
+    public void hitsPerPage() {
         Query query1 = new Query();
         assertNull(query1.getHitsPerPage());
         query1.setHitsPerPage(50);
@@ -236,7 +236,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_allowTyposOnNumericTokens() {
+    public void allowTyposOnNumericTokens() {
         Query query1 = new Query();
         assertNull(query1.getAllowTyposOnNumericTokens());
         query1.setAllowTyposOnNumericTokens(true);
@@ -251,7 +251,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_analytics() {
+    public void analytics() {
         Query query1 = new Query();
         assertNull(query1.getAnalytics());
         query1.setAnalytics(true);
@@ -261,7 +261,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_synonyms() {
+    public void synonyms() {
         Query query1 = new Query();
         assertNull(query1.getSynonyms());
         query1.setSynonyms(true);
@@ -271,7 +271,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_attributesToHighlight() {
+    public void attributesToHighlight() {
         Query query1 = new Query();
         assertNull(query1.getAttributesToHighlight());
         query1.setAttributesToHighlight("foo", "bar");
@@ -281,7 +281,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_attributesToRetrieve() {
+    public void attributesToRetrieve() {
         Query query1 = new Query();
         assertNull(query1.getAttributesToRetrieve());
         query1.setAttributesToRetrieve("foo", "bar");
@@ -291,7 +291,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_attributesToSnippet() {
+    public void attributesToSnippet() {
         Query query1 = new Query();
         assertNull(query1.getAttributesToSnippet());
         query1.setAttributesToSnippet("foo:3", "bar:7");
@@ -301,7 +301,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_query() {
+    public void query() {
         Query query1 = new Query();
         assertNull(query1.getQuery());
         query1.setQuery("supercalifragilisticexpialidocious");
@@ -311,7 +311,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_queryType() {
+    public void queryType() {
         Query query1 = new Query();
         assertNull(query1.getQueryType());
 
@@ -338,7 +338,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_removeWordsIfNoResults() {
+    public void removeWordsIfNoResults() {
         Query query1 = new Query();
         assertNull(query1.getRemoveWordsIfNoResults());
 
@@ -374,7 +374,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_typoTolerance() {
+    public void typoTolerance() {
         Query query1 = new Query();
         assertNull(query1.getTypoTolerance());
 
@@ -410,7 +410,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_facets() {
+    public void facets() {
         Query query1 = new Query();
         assertNull(query1.getFacets());
         query1.setFacets("foo", "bar");
@@ -421,7 +421,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_optionalWords() {
+    public void optionalWords() {
         Query query1 = new Query();
         assertNull(query1.getOptionalWords());
         query1.setOptionalWords("foo", "bar");
@@ -432,7 +432,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_restrictSearchableAttributes() {
+    public void restrictSearchableAttributes() {
         Query query1 = new Query();
         assertNull(query1.getRestrictSearchableAttributes());
         query1.setRestrictSearchableAttributes("foo", "bar");
@@ -443,7 +443,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_highlightPreTag() {
+    public void highlightPreTag() {
         Query query1 = new Query();
         assertNull(query1.getHighlightPreTag());
         query1.setHighlightPreTag("<PRE[");
@@ -454,7 +454,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_highlightPostTag() {
+    public void highlightPostTag() {
         Query query1 = new Query();
         assertNull(query1.getHighlightPostTag());
         query1.setHighlightPostTag("]POST>");
@@ -465,7 +465,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_snippetEllipsisText() {
+    public void snippetEllipsisText() {
         Query query1 = new Query();
         assertNull(query1.getSnippetEllipsisText());
         query1.setSnippetEllipsisText("…");
@@ -476,7 +476,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_analyticsTags() {
+    public void analyticsTags() {
         Query query1 = new Query();
         assertNull(query1.getAnalyticsTags());
         query1.setAnalyticsTags("foo", "bar");
@@ -487,7 +487,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_disableTypoToleranceOnAttributes() {
+    public void disableTypoToleranceOnAttributes() {
         Query query1 = new Query();
         assertNull(query1.getDisableTypoToleranceOnAttributes());
         query1.setDisableTypoToleranceOnAttributes("foo", "bar");
@@ -498,7 +498,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_aroundPrecision() {
+    public void aroundPrecision() {
         Query query1 = new Query();
         assertNull(query1.getAroundPrecision());
         query1.setAroundPrecision(12345);
@@ -509,7 +509,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_aroundRadius() {
+    public void aroundRadius() {
         Query query1 = new Query();
         assertNull(query1.getAroundRadius());
         query1.setAroundRadius(987);
@@ -520,7 +520,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_aroundLatLngViaIP() {
+    public void aroundLatLngViaIP() {
         Query query1 = new Query();
         assertNull(query1.getAroundLatLngViaIP());
         query1.setAroundLatLngViaIP(true);
@@ -531,7 +531,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_aroundLatLng() {
+    public void aroundLatLng() {
         Query query1 = new Query();
         assertNull(query1.getAroundLatLng());
         query1.setAroundLatLng(new Query.LatLng(89.76, -123.45));
@@ -542,7 +542,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_insideBoundingBox() {
+    public void insideBoundingBox() {
         Query query1 = new Query();
         assertNull(query1.getInsideBoundingBox());
         final Query.GeoRect box1 = new Query.GeoRect(new Query.LatLng(11.111111, 22.222222), new Query.LatLng(33.333333, 44.444444));
@@ -562,7 +562,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_insidePolygon() {
+    public void insidePolygon() {
         Query query1 = new Query();
         assertNull(query1.getInsidePolygon());
         final Query.LatLng[] box = { new Query.LatLng(11.111111, 22.222222), new Query.LatLng(33.333333, 44.444444), new Query.LatLng(-55.555555, -66.666666) };
@@ -574,7 +574,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_tagFilters() throws JSONException {
+    public void tagFilters() throws JSONException {
         final JSONArray VALUE = new JSONArray("[\"tag1\", [\"tag2\", \"tag3\"]]");
         Query query1 = new Query();
         assertNull(query1.getTagFilters());
@@ -586,7 +586,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_facetFilters() throws JSONException {
+    public void facetFilters() throws JSONException {
         final JSONArray VALUE = new JSONArray("[[\"category:Book\", \"category:Movie\"], \"author:John Doe\"]");
         Query query1 = new Query();
         assertNull(query1.getFacetFilters());
@@ -598,7 +598,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_advancedSyntax() {
+    public void advancedSyntax() {
         Query query1 = new Query();
         assertNull(query1.getAdvancedSyntax());
         query1.setAdvancedSyntax(true);
@@ -609,7 +609,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_removeStopWordsBoolean() throws Exception {
+    public void removeStopWordsBoolean() throws Exception {
         Query query1 = new Query();
         assertNull(query1.getRemoveStopWords());
         query1.setRemoveStopWords(true);
@@ -620,7 +620,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_removeStopWordsString() throws Exception {
+    public void removeStopWordsString() throws Exception {
         Query query1 = new Query();
         assertNull(query1.getRemoveStopWords());
 
@@ -634,7 +634,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_removeStopWordsInvalidClass() throws Exception {
+    public void removeStopWordsInvalidClass() throws Exception {
         Query query1 = new Query();
         try {
             query1.setRemoveStopWords(42);
@@ -645,7 +645,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_maxValuesPerFacet() {
+    public void maxValuesPerFacet() {
         Query query1 = new Query();
         assertNull(query1.getMaxValuesPerFacet());
         query1.setMaxValuesPerFacet(456);
@@ -656,7 +656,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_minimumAroundRadius() {
+    public void minimumAroundRadius() {
         Query query1 = new Query();
         assertNull(query1.getMinimumAroundRadius());
         query1.setMinimumAroundRadius(1000);
@@ -667,7 +667,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_numericFilters() throws JSONException {
+    public void numericFilters() throws JSONException {
         final JSONArray VALUE = new JSONArray("[\"code=1\", [\"price:0 to 10\", \"price:1000 to 2000\"]]");
         Query query1 = new Query();
         assertNull(query1.getNumericFilters());
@@ -679,7 +679,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_filters() {
+    public void filters() {
         final String VALUE = "available=1 AND (category:Book OR NOT category:Ebook) AND publication_date: 1441745506 TO 1441755506 AND inStock > 0 AND author:\"John Doe\"";
         Query query1 = new Query();
         assertNull(query1.getFilters());
@@ -691,7 +691,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_exactOnSingleWordQuery() {
+    public void exactOnSingleWordQuery() {
         Query.ExactOnSingleWordQuery VALUE = Query.ExactOnSingleWordQuery.ATTRIBUTE;
         Query query = new Query();
         assertNull(query.getExactOnSingleWordQuery());
@@ -704,7 +704,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_alternativesAsExact() {
+    public void alternativesAsExact() {
         Query.AlternativesAsExact VALUE1 = Query.AlternativesAsExact.IGNORE_PLURALS;
         Query.AlternativesAsExact VALUE2 = Query.AlternativesAsExact.MULTI_WORDS_SYNONYM;
         final Query.AlternativesAsExact[] VALUES = new Query.AlternativesAsExact[]{VALUE1, VALUE2};
@@ -726,7 +726,7 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void test_aroundRadius_all() {
+    public void aroundRadius_all() {
         final Integer VALUE = 3;
         Query query = new Query();
         assertNull("A new query should have a null aroundRadius.", query.getAroundRadius());

--- a/algoliasearch/src/test/java/com/algolia/search/saas/QueryTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/QueryTest.java
@@ -483,7 +483,7 @@ public class QueryTest extends RobolectricTestCase {
         assertArrayEquals(new String[]{ "foo", "bar" }, query1.getAnalyticsTags());
         assertEquals("[\"foo\",\"bar\"]", query1.get("analyticsTags"));
         Query query2 = Query.parse(query1.build());
-        assertArrayEquals(new String[]{ "foo", "bar" }, query2.getAnalyticsTags());
+        assertArrayEquals(query1.getAnalyticsTags(), query2.getAnalyticsTags());
     }
 
     @Test

--- a/algoliasearch/src/test/java/com/algolia/search/saas/QueryTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/QueryTest.java
@@ -735,13 +735,13 @@ public class QueryTest extends RobolectricTestCase {
         assertEquals("After setting its aroundRadius to a given integer, we should return it from getAroundRadius.", VALUE, query.getAroundRadius());
 
         String queryStr = query.build();
-        assertTrue("The built query should contain 'aroundRadius=" + VALUE + "'.", queryStr.matches("aroundRadius=" + VALUE));
+        assertTrue("The built query should contain 'aroundRadius=" + VALUE + "'.", queryStr.contains("aroundRadius=" + VALUE));
 
         query.setAroundRadius(Query.RADIUS_ALL);
         assertEquals("After setting it to RADIUS_ALL, a query should have this aroundRadius value.", Integer.valueOf(Query.RADIUS_ALL), query.getAroundRadius());
 
         queryStr = query.build();
-        assertTrue("The built query should contain 'aroundRadius=all', not _" + queryStr + "_.", queryStr.matches("aroundRadius=all"));
+        assertTrue("The built query should contain 'aroundRadius=all', not _" + queryStr + "_.", queryStr.contains("aroundRadius=all"));
         Query query2 = Query.parse(query.build());
         assertEquals(query2.getAroundRadius(), query.getAroundRadius());
     }

--- a/algoliasearch/src/test/java/com/algolia/search/saas/QueryTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/QueryTest.java
@@ -55,7 +55,7 @@ public class QueryTest extends RobolectricTestCase {
         query.set("b", "B");
         query.set("a", "A");
         String queryString = query.build();
-        assertEquals(queryString, "a=A&b=B&c=C");
+        assertEquals("a=A&b=B&c=C", queryString);
     }
 
     /** Test parsing a query from a URL query string. */
@@ -79,7 +79,7 @@ public class QueryTest extends RobolectricTestCase {
         query1.set("accented", "éêèàôù");
         query1.set("escaped", " %&=#+");
         String queryString = query1.build();
-        assertEquals(queryString, "accented=%C3%A9%C3%AA%C3%A8%C3%A0%C3%B4%C3%B9&escaped=%20%25%26%3D%23%2B");
+        assertEquals("accented=%C3%A9%C3%AA%C3%A8%C3%A0%C3%B4%C3%B9&escaped=%20%25%26%3D%23%2B", queryString);
 
         // Test parsing of escaped characters.
         Query query2 = Query.parse(queryString);
@@ -97,7 +97,7 @@ public class QueryTest extends RobolectricTestCase {
 
         // Test accessors.
         query.set("a", "A");
-        assertEquals(query.get("a"), "A");
+        assertEquals("A", query.get("a"));
 
         // Test setting null.
         query.set("a", null);
@@ -115,9 +115,9 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getMinWordSizefor1Typo());
         query1.setMinWordSizefor1Typo(123);
-        assertEquals(query1.getMinWordSizefor1Typo(), new Integer(123));
+        assertEquals(new Integer(123), query1.getMinWordSizefor1Typo());
         Query query2 = Query.parse(query1.build());
-        assertEquals(query2.getMinWordSizefor1Typo(), query1.getMinWordSizefor1Typo());
+        assertEquals(query1.getMinWordSizefor1Typo(), query2.getMinWordSizefor1Typo());
     }
 
     @Test
@@ -125,9 +125,9 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getMinWordSizefor2Typos());
         query1.setMinWordSizefor2Typos(456);
-        assertEquals(query1.getMinWordSizefor2Typos(), new Integer(456));
+        assertEquals(new Integer(456), query1.getMinWordSizefor2Typos());
         Query query2 = Query.parse(query1.build());
-        assertEquals(query2.getMinWordSizefor2Typos(), query1.getMinWordSizefor2Typos());
+        assertEquals(query1.getMinWordSizefor2Typos(), query2.getMinWordSizefor2Typos());
     }
 
     @Test
@@ -135,9 +135,9 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getMinProximity());
         query1.setMinProximity(999);
-        assertEquals(query1.getMinProximity(), new Integer(999));
+        assertEquals(new Integer(999), query1.getMinProximity());
         Query query2 = Query.parse(query1.build());
-        assertEquals(query2.getMinProximity(), query1.getMinProximity());
+        assertEquals(query1.getMinProximity(), query2.getMinProximity());
     }
 
     @Test
@@ -145,14 +145,14 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getGetRankingInfo());
         query1.setGetRankingInfo(true);
-        assertEquals(query1.getGetRankingInfo(), Boolean.TRUE);
+        assertEquals(Boolean.TRUE, query1.getGetRankingInfo());
         Query query2 = Query.parse(query1.build());
-        assertEquals(query2.getGetRankingInfo(), query1.getGetRankingInfo());
+        assertEquals(query1.getGetRankingInfo(), query2.getGetRankingInfo());
 
         query1.setGetRankingInfo(false);
-        assertEquals(query1.getGetRankingInfo(), Boolean.FALSE);
+        assertEquals(Boolean.FALSE, query1.getGetRankingInfo());
         Query query3 = Query.parse(query1.build());
-        assertEquals(query3.getGetRankingInfo(), query1.getGetRankingInfo());
+        assertEquals(query1.getGetRankingInfo(), query3.getGetRankingInfo());
     }
 
     @Test
@@ -210,9 +210,9 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getDistinct());
         query1.setDistinct(100);
-        assertEquals(query1.getDistinct(), new Integer(100));
+        assertEquals(new Integer(100), query1.getDistinct());
         Query query2 = Query.parse(query1.build());
-        assertEquals(query2.getDistinct(), query1.getDistinct());
+        assertEquals(query1.getDistinct(), query2.getDistinct());
     }
 
     @Test
@@ -220,9 +220,9 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getPage());
         query1.setPage(0);
-        assertEquals(query1.getPage(), new Integer(0));
+        assertEquals(new Integer(0), query1.getPage());
         Query query2 = Query.parse(query1.build());
-        assertEquals(query2.getPage(), query1.getPage());
+        assertEquals(query1.getPage(), query2.getPage());
     }
 
     @Test
@@ -230,9 +230,9 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getHitsPerPage());
         query1.setHitsPerPage(50);
-        assertEquals(query1.getHitsPerPage(), new Integer(50));
+        assertEquals(new Integer(50), query1.getHitsPerPage());
         Query query2 = Query.parse(query1.build());
-        assertEquals(query2.getHitsPerPage(), query1.getHitsPerPage());
+        assertEquals(query1.getHitsPerPage(), query2.getHitsPerPage());
     }
 
     @Test
@@ -240,14 +240,14 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getAllowTyposOnNumericTokens());
         query1.setAllowTyposOnNumericTokens(true);
-        assertEquals(query1.getAllowTyposOnNumericTokens(), Boolean.TRUE);
+        assertEquals(Boolean.TRUE, query1.getAllowTyposOnNumericTokens());
         Query query2 = Query.parse(query1.build());
-        assertEquals(query2.getAllowTyposOnNumericTokens(), query1.getAllowTyposOnNumericTokens());
+        assertEquals(query1.getAllowTyposOnNumericTokens(), query2.getAllowTyposOnNumericTokens());
 
         query1.setAllowTyposOnNumericTokens(false);
-        assertEquals(query1.getAllowTyposOnNumericTokens(), Boolean.FALSE);
+        assertEquals(Boolean.FALSE, query1.getAllowTyposOnNumericTokens());
         Query query3 = Query.parse(query1.build());
-        assertEquals(query3.getAllowTyposOnNumericTokens(), query1.getAllowTyposOnNumericTokens());
+        assertEquals(query1.getAllowTyposOnNumericTokens(), query3.getAllowTyposOnNumericTokens());
     }
 
     @Test
@@ -255,9 +255,9 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getAnalytics());
         query1.setAnalytics(true);
-        assertEquals(query1.getAnalytics(), Boolean.TRUE);
+        assertEquals(Boolean.TRUE, query1.getAnalytics());
         Query query2 = Query.parse(query1.build());
-        assertEquals(query2.getAnalytics(), query1.getAnalytics());
+        assertEquals(query1.getAnalytics(), query2.getAnalytics());
     }
 
     @Test
@@ -265,9 +265,9 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getSynonyms());
         query1.setSynonyms(true);
-        assertEquals(query1.getSynonyms(), Boolean.TRUE);
+        assertEquals(Boolean.TRUE, query1.getSynonyms());
         Query query2 = Query.parse(query1.build());
-        assertEquals(query2.getSynonyms(), query1.getSynonyms());
+        assertEquals(query1.getSynonyms(), query2.getSynonyms());
     }
 
     @Test
@@ -275,9 +275,9 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getAttributesToHighlight());
         query1.setAttributesToHighlight("foo", "bar");
-        assertArrayEquals(query1.getAttributesToHighlight(), new String[]{ "foo", "bar" });
+        assertArrayEquals(new String[]{ "foo", "bar" }, query1.getAttributesToHighlight());
         Query query2 = Query.parse(query1.build());
-        assertArrayEquals(query2.getAttributesToHighlight(), query1.getAttributesToHighlight());
+        assertArrayEquals(query1.getAttributesToHighlight(), query2.getAttributesToHighlight());
     }
 
     @Test
@@ -285,9 +285,9 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getAttributesToRetrieve());
         query1.setAttributesToRetrieve("foo", "bar");
-        assertArrayEquals(query1.getAttributesToRetrieve(), new String[]{ "foo", "bar" });
+        assertArrayEquals(new String[]{ "foo", "bar" }, query1.getAttributesToRetrieve());
         Query query2 = Query.parse(query1.build());
-        assertArrayEquals(query2.getAttributesToRetrieve(), query1.getAttributesToRetrieve());
+        assertArrayEquals(query1.getAttributesToRetrieve(), query2.getAttributesToRetrieve());
     }
 
     @Test
@@ -295,9 +295,9 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getAttributesToSnippet());
         query1.setAttributesToSnippet("foo:3", "bar:7");
-        assertArrayEquals(query1.getAttributesToSnippet(), new String[]{ "foo:3", "bar:7" });
+        assertArrayEquals(new String[]{ "foo:3", "bar:7" }, query1.getAttributesToSnippet());
         Query query2 = Query.parse(query1.build());
-        assertArrayEquals(query2.getAttributesToSnippet(), query1.getAttributesToSnippet());
+        assertArrayEquals(query1.getAttributesToSnippet(), query2.getAttributesToSnippet());
     }
 
     @Test
@@ -305,9 +305,9 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getQuery());
         query1.setQuery("supercalifragilisticexpialidocious");
-        assertEquals(query1.getQuery(), "supercalifragilisticexpialidocious");
+        assertEquals("supercalifragilisticexpialidocious", query1.getQuery());
         Query query2 = Query.parse(query1.build());
-        assertEquals(query2.getQuery(), query1.getQuery());
+        assertEquals(query1.getQuery(), query2.getQuery());
     }
 
     @Test
@@ -316,22 +316,22 @@ public class QueryTest extends RobolectricTestCase {
         assertNull(query1.getQueryType());
 
         query1.setQueryType(Query.QueryType.PREFIX_ALL);
-        assertEquals(query1.getQueryType(), Query.QueryType.PREFIX_ALL);
-        assertEquals(query1.get("queryType"), "prefixAll");
+        assertEquals(Query.QueryType.PREFIX_ALL, query1.getQueryType());
+        assertEquals("prefixAll", query1.get("queryType"));
         Query query2 = Query.parse(query1.build());
-        assertEquals(query2.getQueryType(), query1.getQueryType());
+        assertEquals(query1.getQueryType(), query2.getQueryType());
 
         query1.setQueryType(Query.QueryType.PREFIX_LAST);
-        assertEquals(query1.getQueryType(), Query.QueryType.PREFIX_LAST);
-        assertEquals(query1.get("queryType"), "prefixLast");
+        assertEquals(Query.QueryType.PREFIX_LAST, query1.getQueryType());
+        assertEquals("prefixLast", query1.get("queryType"));
         query2 = Query.parse(query1.build());
-        assertEquals(query2.getQueryType(), query1.getQueryType());
+        assertEquals(query1.getQueryType(), query2.getQueryType());
 
         query1.setQueryType(Query.QueryType.PREFIX_NONE);
         assertEquals(query1.getQueryType(), Query.QueryType.PREFIX_NONE);
         assertEquals(query1.get("queryType"), "prefixNone");
         query2 = Query.parse(query1.build());
-        assertEquals(query2.getQueryType(), query1.getQueryType());
+        assertEquals(query1.getQueryType(), query2.getQueryType());
 
         query1.set("queryType", "invalid");
         assertNull(query1.getQueryType());
@@ -343,34 +343,34 @@ public class QueryTest extends RobolectricTestCase {
         assertNull(query1.getRemoveWordsIfNoResults());
 
         query1.setRemoveWordsIfNoResults(Query.RemoveWordsIfNoResults.ALL_OPTIONAL);
-        assertEquals(query1.getRemoveWordsIfNoResults(), Query.RemoveWordsIfNoResults.ALL_OPTIONAL);
-        assertEquals(query1.get("removeWordsIfNoResults"), "allOptional");
+        assertEquals(Query.RemoveWordsIfNoResults.ALL_OPTIONAL, query1.getRemoveWordsIfNoResults());
+        assertEquals("allOptional", query1.get("removeWordsIfNoResults"));
         Query query2 = Query.parse(query1.build());
-        assertEquals(query2.getRemoveWordsIfNoResults(), query1.getRemoveWordsIfNoResults());
+        assertEquals(query1.getRemoveWordsIfNoResults(), query2.getRemoveWordsIfNoResults());
 
         query1.setRemoveWordsIfNoResults(Query.RemoveWordsIfNoResults.FIRST_WORDS);
-        assertEquals(query1.getRemoveWordsIfNoResults(), Query.RemoveWordsIfNoResults.FIRST_WORDS);
-        assertEquals(query1.get("removeWordsIfNoResults"), "firstWords");
+        assertEquals(Query.RemoveWordsIfNoResults.FIRST_WORDS, query1.getRemoveWordsIfNoResults());
+        assertEquals("firstWords", query1.get("removeWordsIfNoResults"));
         query2 = Query.parse(query1.build());
-        assertEquals(query2.getRemoveWordsIfNoResults(), query1.getRemoveWordsIfNoResults());
+        assertEquals(query1.getRemoveWordsIfNoResults(), query2.getRemoveWordsIfNoResults());
 
         query1.setRemoveWordsIfNoResults(Query.RemoveWordsIfNoResults.LAST_WORDS);
-        assertEquals(query1.getRemoveWordsIfNoResults(), Query.RemoveWordsIfNoResults.LAST_WORDS);
-        assertEquals(query1.get("removeWordsIfNoResults"), "lastWords");
+        assertEquals(Query.RemoveWordsIfNoResults.LAST_WORDS, query1.getRemoveWordsIfNoResults());
+        assertEquals("lastWords", query1.get("removeWordsIfNoResults"));
         query2 = Query.parse(query1.build());
-        assertEquals(query2.getRemoveWordsIfNoResults(), query1.getRemoveWordsIfNoResults());
+        assertEquals(query1.getRemoveWordsIfNoResults(), query2.getRemoveWordsIfNoResults());
 
         query1.setRemoveWordsIfNoResults(Query.RemoveWordsIfNoResults.NONE);
-        assertEquals(query1.getRemoveWordsIfNoResults(), Query.RemoveWordsIfNoResults.NONE);
-        assertEquals(query1.get("removeWordsIfNoResults"), "none");
+        assertEquals(Query.RemoveWordsIfNoResults.NONE, query1.getRemoveWordsIfNoResults());
+        assertEquals("none", query1.get("removeWordsIfNoResults"));
         query2 = Query.parse(query1.build());
-        assertEquals(query2.getRemoveWordsIfNoResults(), query1.getRemoveWordsIfNoResults());
+        assertEquals(query1.getRemoveWordsIfNoResults(), query2.getRemoveWordsIfNoResults());
 
         query1.set("removeWordsIfNoResults", "invalid");
         assertNull(query1.getRemoveWordsIfNoResults());
 
         query1.set("removeWordsIfNoResults", "allOptional");
-        assertEquals(query1.getRemoveWordsIfNoResults(), Query.RemoveWordsIfNoResults.ALL_OPTIONAL);
+        assertEquals(Query.RemoveWordsIfNoResults.ALL_OPTIONAL, query1.getRemoveWordsIfNoResults());
     }
 
     @Test
@@ -379,34 +379,34 @@ public class QueryTest extends RobolectricTestCase {
         assertNull(query1.getTypoTolerance());
 
         query1.setTypoTolerance(Query.TypoTolerance.TRUE);
-        assertEquals(query1.getTypoTolerance(), Query.TypoTolerance.TRUE);
-        assertEquals(query1.get("typoTolerance"), "true");
+        assertEquals(Query.TypoTolerance.TRUE, query1.getTypoTolerance());
+        assertEquals("true", query1.get("typoTolerance"));
         Query query2 = Query.parse(query1.build());
-        assertEquals(query2.getTypoTolerance(), query1.getTypoTolerance());
+        assertEquals(query1.getTypoTolerance(), query2.getTypoTolerance());
 
         query1.setTypoTolerance(Query.TypoTolerance.FALSE);
-        assertEquals(query1.getTypoTolerance(), Query.TypoTolerance.FALSE);
-        assertEquals(query1.get("typoTolerance"), "false");
+        assertEquals(Query.TypoTolerance.FALSE, query1.getTypoTolerance());
+        assertEquals("false", query1.get("typoTolerance"));
         query2 = Query.parse(query1.build());
-        assertEquals(query2.getTypoTolerance(), query1.getTypoTolerance());
+        assertEquals(query1.getTypoTolerance(), query2.getTypoTolerance());
 
         query1.setTypoTolerance(Query.TypoTolerance.MIN);
-        assertEquals(query1.getTypoTolerance(), Query.TypoTolerance.MIN);
-        assertEquals(query1.get("typoTolerance"), "min");
+        assertEquals(Query.TypoTolerance.MIN, query1.getTypoTolerance());
+        assertEquals("min", query1.get("typoTolerance"));
         query2 = Query.parse(query1.build());
-        assertEquals(query2.getTypoTolerance(), query1.getTypoTolerance());
+        assertEquals(query1.getTypoTolerance(), query2.getTypoTolerance());
 
         query1.setTypoTolerance(Query.TypoTolerance.STRICT);
-        assertEquals(query1.getTypoTolerance(), Query.TypoTolerance.STRICT);
-        assertEquals(query1.get("typoTolerance"), "strict");
+        assertEquals(Query.TypoTolerance.STRICT, query1.getTypoTolerance());
+        assertEquals("strict", query1.get("typoTolerance"));
         query2 = Query.parse(query1.build());
-        assertEquals(query2.getTypoTolerance(), query1.getTypoTolerance());
+        assertEquals(query1.getTypoTolerance(), query2.getTypoTolerance());
 
         query1.set("typoTolerance", "invalid");
         assertNull(query1.getTypoTolerance());
 
         query1.set("typoTolerance", "true");
-        assertEquals(query1.getTypoTolerance(), Query.TypoTolerance.TRUE);
+        assertEquals(Query.TypoTolerance.TRUE, query1.getTypoTolerance());
     }
 
     @Test
@@ -414,10 +414,10 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getFacets());
         query1.setFacets("foo", "bar");
-        assertArrayEquals(query1.getFacets(), new String[]{ "foo", "bar" });
-        assertEquals(query1.get("facets"), "[\"foo\",\"bar\"]");
+        assertArrayEquals(new String[]{ "foo", "bar" }, query1.getFacets());
+        assertEquals("[\"foo\",\"bar\"]", query1.get("facets"));
         Query query2 = Query.parse(query1.build());
-        assertArrayEquals(query2.getFacets(), query1.getFacets());
+        assertArrayEquals(query1.getFacets(), query2.getFacets());
     }
 
     @Test
@@ -425,10 +425,10 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getOptionalWords());
         query1.setOptionalWords("foo", "bar");
-        assertArrayEquals(query1.getOptionalWords(), new String[]{ "foo", "bar" });
-        assertEquals(query1.get("optionalWords"), "[\"foo\",\"bar\"]");
+        assertArrayEquals(new String[]{ "foo", "bar" }, query1.getOptionalWords());
+        assertEquals("[\"foo\",\"bar\"]", query1.get("optionalWords"));
         Query query2 = Query.parse(query1.build());
-        assertArrayEquals(query2.getOptionalWords(), query1.getOptionalWords());
+        assertArrayEquals(query1.getOptionalWords(), query2.getOptionalWords());
     }
 
     @Test
@@ -436,10 +436,10 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getRestrictSearchableAttributes());
         query1.setRestrictSearchableAttributes("foo", "bar");
-        assertArrayEquals(query1.getRestrictSearchableAttributes(), new String[]{ "foo", "bar" });
-        assertEquals(query1.get("restrictSearchableAttributes"), "[\"foo\",\"bar\"]");
+        assertArrayEquals(new String[]{ "foo", "bar" }, query1.getRestrictSearchableAttributes());
+        assertEquals("[\"foo\",\"bar\"]", query1.get("restrictSearchableAttributes"));
         Query query2 = Query.parse(query1.build());
-        assertArrayEquals(query2.getRestrictSearchableAttributes(), query1.getRestrictSearchableAttributes());
+        assertArrayEquals(query1.getRestrictSearchableAttributes(), query2.getRestrictSearchableAttributes());
     }
 
     @Test
@@ -447,10 +447,10 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getHighlightPreTag());
         query1.setHighlightPreTag("<PRE[");
-        assertEquals(query1.getHighlightPreTag(), "<PRE[");
-        assertEquals(query1.get("highlightPreTag"), "<PRE[");
+        assertEquals("<PRE[", query1.getHighlightPreTag());
+        assertEquals("<PRE[", query1.get("highlightPreTag"));
         Query query2 = Query.parse(query1.build());
-        assertEquals(query2.getHighlightPreTag(), query1.getHighlightPreTag());
+        assertEquals(query1.getHighlightPreTag(), query2.getHighlightPreTag());
     }
 
     @Test
@@ -458,10 +458,10 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getHighlightPostTag());
         query1.setHighlightPostTag("]POST>");
-        assertEquals(query1.getHighlightPostTag(), "]POST>");
-        assertEquals(query1.get("highlightPostTag"), "]POST>");
+        assertEquals("]POST>", query1.getHighlightPostTag());
+        assertEquals("]POST>", query1.get("highlightPostTag"));
         Query query2 = Query.parse(query1.build());
-        assertEquals(query2.getHighlightPostTag(), query1.getHighlightPostTag());
+        assertEquals(query1.getHighlightPostTag(), query2.getHighlightPostTag());
     }
 
     @Test
@@ -469,10 +469,10 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getSnippetEllipsisText());
         query1.setSnippetEllipsisText("…");
-        assertEquals(query1.getSnippetEllipsisText(), "…");
-        assertEquals(query1.get("snippetEllipsisText"), "…");
+        assertEquals("…", query1.getSnippetEllipsisText());
+        assertEquals("…", query1.get("snippetEllipsisText"));
         Query query2 = Query.parse(query1.build());
-        assertEquals(query2.getSnippetEllipsisText(), query1.getSnippetEllipsisText());
+        assertEquals(query1.getSnippetEllipsisText(), query2.getSnippetEllipsisText());
     }
 
     @Test
@@ -480,10 +480,10 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getAnalyticsTags());
         query1.setAnalyticsTags("foo", "bar");
-        assertArrayEquals(query1.getAnalyticsTags(), new String[]{ "foo", "bar" });
-        assertEquals(query1.get("analyticsTags"), "[\"foo\",\"bar\"]");
+        assertArrayEquals(new String[]{ "foo", "bar" }, query1.getAnalyticsTags());
+        assertEquals("[\"foo\",\"bar\"]", query1.get("analyticsTags"));
         Query query2 = Query.parse(query1.build());
-        assertArrayEquals(query2.getAnalyticsTags(), new String[]{ "foo", "bar" });
+        assertArrayEquals(new String[]{ "foo", "bar" }, query2.getAnalyticsTags());
     }
 
     @Test
@@ -491,10 +491,10 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getDisableTypoToleranceOnAttributes());
         query1.setDisableTypoToleranceOnAttributes("foo", "bar");
-        assertArrayEquals(query1.getDisableTypoToleranceOnAttributes(), new String[]{ "foo", "bar" });
-        assertEquals(query1.get("disableTypoToleranceOnAttributes"), "[\"foo\",\"bar\"]");
+        assertArrayEquals(new String[]{ "foo", "bar" }, query1.getDisableTypoToleranceOnAttributes());
+        assertEquals("[\"foo\",\"bar\"]", query1.get("disableTypoToleranceOnAttributes"));
         Query query2 = Query.parse(query1.build());
-        assertArrayEquals(query2.getDisableTypoToleranceOnAttributes(), query1.getDisableTypoToleranceOnAttributes());
+        assertArrayEquals(query1.getDisableTypoToleranceOnAttributes(), query2.getDisableTypoToleranceOnAttributes());
     }
 
     @Test
@@ -502,10 +502,10 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getAroundPrecision());
         query1.setAroundPrecision(12345);
-        assertEquals(query1.getAroundPrecision(), new Integer(12345));
-        assertEquals(query1.get("aroundPrecision"), "12345");
+        assertEquals(new Integer(12345), query1.getAroundPrecision());
+        assertEquals("12345", query1.get("aroundPrecision"));
         Query query2 = Query.parse(query1.build());
-        assertEquals(query2.getAroundPrecision(), query1.getAroundPrecision());
+        assertEquals(query1.getAroundPrecision(), query2.getAroundPrecision());
     }
 
     @Test
@@ -513,10 +513,10 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getAroundRadius());
         query1.setAroundRadius(987);
-        assertEquals(query1.getAroundRadius(), new Integer(987));
-        assertEquals(query1.get("aroundRadius"), "987");
+        assertEquals(new Integer(987), query1.getAroundRadius());
+        assertEquals("987", query1.get("aroundRadius"));
         Query query2 = Query.parse(query1.build());
-        assertEquals(query2.getAroundRadius(), query1.getAroundRadius());
+        assertEquals(query1.getAroundRadius(), query2.getAroundRadius());
     }
 
     @Test
@@ -524,10 +524,10 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getAroundLatLngViaIP());
         query1.setAroundLatLngViaIP(true);
-        assertEquals(query1.getAroundLatLngViaIP(), Boolean.TRUE);
-        assertEquals(query1.get("aroundLatLngViaIP"), "true");
+        assertEquals(Boolean.TRUE, query1.getAroundLatLngViaIP());
+        assertEquals("true", query1.get("aroundLatLngViaIP"));
         Query query2 = Query.parse(query1.build());
-        assertEquals(query2.getAroundLatLngViaIP(), query1.getAroundLatLngViaIP());
+        assertEquals(query1.getAroundLatLngViaIP(), query2.getAroundLatLngViaIP());
     }
 
     @Test
@@ -535,10 +535,10 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getAroundLatLng());
         query1.setAroundLatLng(new Query.LatLng(89.76, -123.45));
-        assertEquals(query1.getAroundLatLng(), new Query.LatLng(89.76, -123.45));
-        assertEquals(query1.get("aroundLatLng"), "89.76,-123.45");
+        assertEquals(new Query.LatLng(89.76, -123.45), query1.getAroundLatLng());
+        assertEquals("89.76,-123.45", query1.get("aroundLatLng"));
         Query query2 = Query.parse(query1.build());
-        assertEquals(query2.getAroundLatLng(), query1.getAroundLatLng());
+        assertEquals(query1.getAroundLatLng(), query2.getAroundLatLng());
     }
 
     @Test
@@ -547,18 +547,18 @@ public class QueryTest extends RobolectricTestCase {
         assertNull(query1.getInsideBoundingBox());
         final Query.GeoRect box1 = new Query.GeoRect(new Query.LatLng(11.111111, 22.222222), new Query.LatLng(33.333333, 44.444444));
         query1.setInsideBoundingBox(box1);
-        assertArrayEquals(query1.getInsideBoundingBox(), new Query.GeoRect[]{ box1 });
-        assertEquals(query1.get("insideBoundingBox"), "11.111111,22.222222,33.333333,44.444444");
+        assertArrayEquals(new Query.GeoRect[]{ box1 }, query1.getInsideBoundingBox());
+        assertEquals("11.111111,22.222222,33.333333,44.444444", query1.get("insideBoundingBox"));
         Query query2 = Query.parse(query1.build());
-        assertArrayEquals(query2.getInsideBoundingBox(), query1.getInsideBoundingBox());
+        assertArrayEquals(query1.getInsideBoundingBox(), query2.getInsideBoundingBox());
 
         final Query.GeoRect box2 = new Query.GeoRect(new Query.LatLng(-55.555555, -66.666666), new Query.LatLng(-77.777777, -88.888888));
         final Query.GeoRect[] boxes = { box1, box2 };
         query1.setInsideBoundingBox(boxes);
-        assertArrayEquals(query1.getInsideBoundingBox(), boxes);
-        assertEquals(query1.get("insideBoundingBox"), "11.111111,22.222222,33.333333,44.444444,-55.555555,-66.666666,-77.777777,-88.888888");
+        assertArrayEquals(boxes, query1.getInsideBoundingBox());
+        assertEquals("11.111111,22.222222,33.333333,44.444444,-55.555555,-66.666666,-77.777777,-88.888888", query1.get("insideBoundingBox"));
         query2 = Query.parse(query1.build());
-        assertArrayEquals(query2.getInsideBoundingBox(), query1.getInsideBoundingBox());
+        assertArrayEquals(query1.getInsideBoundingBox(), query2.getInsideBoundingBox());
     }
 
     @Test
@@ -567,10 +567,10 @@ public class QueryTest extends RobolectricTestCase {
         assertNull(query1.getInsidePolygon());
         final Query.LatLng[] box = { new Query.LatLng(11.111111, 22.222222), new Query.LatLng(33.333333, 44.444444), new Query.LatLng(-55.555555, -66.666666) };
         query1.setInsidePolygon(box);
-        assertArrayEquals(query1.getInsidePolygon(), box);
-        assertEquals(query1.get("insidePolygon"), "11.111111,22.222222,33.333333,44.444444,-55.555555,-66.666666");
+        assertArrayEquals(box, query1.getInsidePolygon());
+        assertEquals("11.111111,22.222222,33.333333,44.444444,-55.555555,-66.666666", query1.get("insidePolygon"));
         Query query2 = Query.parse(query1.build());
-        assertArrayEquals(query2.getInsidePolygon(), query1.getInsidePolygon());
+        assertArrayEquals(query1.getInsidePolygon(), query2.getInsidePolygon());
     }
 
     @Test
@@ -579,10 +579,10 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getTagFilters());
         query1.setTagFilters(VALUE);
-        assertEquals(query1.getTagFilters(), VALUE);
-        assertEquals(query1.get("tagFilters"), "[\"tag1\",[\"tag2\",\"tag3\"]]");
+        assertEquals(VALUE, query1.getTagFilters());
+        assertEquals("[\"tag1\",[\"tag2\",\"tag3\"]]", query1.get("tagFilters"));
         Query query2 = Query.parse(query1.build());
-        assertEquals(query2.getTagFilters(), query1.getTagFilters());
+        assertEquals(query1.getTagFilters(), query2.getTagFilters());
     }
 
     @Test
@@ -591,10 +591,10 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getFacetFilters());
         query1.setFacetFilters(VALUE);
-        assertEquals(query1.getFacetFilters(), VALUE);
-        assertEquals(query1.get("facetFilters"), "[[\"category:Book\",\"category:Movie\"],\"author:John Doe\"]");
+        assertEquals(VALUE, query1.getFacetFilters());
+        assertEquals("[[\"category:Book\",\"category:Movie\"],\"author:John Doe\"]", query1.get("facetFilters"));
         Query query2 = Query.parse(query1.build());
-        assertEquals(query2.getFacetFilters(), query1.getFacetFilters());
+        assertEquals(query1.getFacetFilters(), query2.getFacetFilters());
     }
 
     @Test
@@ -602,10 +602,10 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getAdvancedSyntax());
         query1.setAdvancedSyntax(true);
-        assertEquals(query1.getAdvancedSyntax(), Boolean.TRUE);
-        assertEquals(query1.get("advancedSyntax"), "true");
+        assertEquals(Boolean.TRUE, query1.getAdvancedSyntax());
+        assertEquals("true", query1.get("advancedSyntax"));
         Query query2 = Query.parse(query1.build());
-        assertEquals(query2.getAdvancedSyntax(), query1.getAdvancedSyntax());
+        assertEquals(query1.getAdvancedSyntax(), query2.getAdvancedSyntax());
     }
 
     @Test
@@ -649,10 +649,10 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getMaxValuesPerFacet());
         query1.setMaxValuesPerFacet(456);
-        assertEquals(query1.getMaxValuesPerFacet(), new Integer(456));
-        assertEquals(query1.get("maxValuesPerFacet"), "456");
+        assertEquals(new Integer(456), query1.getMaxValuesPerFacet());
+        assertEquals("456", query1.get("maxValuesPerFacet"));
         Query query2 = Query.parse(query1.build());
-        assertEquals(query2.getMaxValuesPerFacet(), query1.getMaxValuesPerFacet());
+        assertEquals(query1.getMaxValuesPerFacet(), query2.getMaxValuesPerFacet());
     }
 
     @Test
@@ -660,10 +660,10 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getMinimumAroundRadius());
         query1.setMinimumAroundRadius(1000);
-        assertEquals(query1.getMinimumAroundRadius(), new Integer(1000));
-        assertEquals(query1.get("minimumAroundRadius"), "1000");
+        assertEquals(new Integer(1000), query1.getMinimumAroundRadius());
+        assertEquals("1000", query1.get("minimumAroundRadius"));
         Query query2 = Query.parse(query1.build());
-        assertEquals(query2.getMinimumAroundRadius(), query1.getMinimumAroundRadius());
+        assertEquals(query1.getMinimumAroundRadius(), query2.getMinimumAroundRadius());
     }
 
     @Test
@@ -672,10 +672,10 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getNumericFilters());
         query1.setNumericFilters(VALUE);
-        assertEquals(query1.getNumericFilters(), VALUE);
-        assertEquals(query1.get("numericFilters"), "[\"code=1\",[\"price:0 to 10\",\"price:1000 to 2000\"]]");
+        assertEquals(VALUE, query1.getNumericFilters());
+        assertEquals("[\"code=1\",[\"price:0 to 10\",\"price:1000 to 2000\"]]", query1.get("numericFilters"));
         Query query2 = Query.parse(query1.build());
-        assertEquals(query2.getNumericFilters(), query1.getNumericFilters());
+        assertEquals(query1.getNumericFilters(), query2.getNumericFilters());
     }
 
     @Test
@@ -684,10 +684,10 @@ public class QueryTest extends RobolectricTestCase {
         Query query1 = new Query();
         assertNull(query1.getFilters());
         query1.setFilters(VALUE);
-        assertEquals(query1.getFilters(), VALUE);
-        assertEquals(query1.get("filters"), VALUE);
+        assertEquals(VALUE, query1.getFilters());
+        assertEquals(VALUE, query1.get("filters"));
         Query query2 = Query.parse(query1.build());
-        assertEquals(query2.getFilters(), query1.getFilters());
+        assertEquals(query1.getFilters(), query2.getFilters());
     }
 
     @Test
@@ -697,10 +697,10 @@ public class QueryTest extends RobolectricTestCase {
         assertNull(query.getExactOnSingleWordQuery());
 
         query.setExactOnSingleWordQuery(VALUE);
-        assertEquals(query.getExactOnSingleWordQuery(), VALUE);
-        assertEquals(query.get("exactOnSingleWordQuery"), "attribute");
+        assertEquals(VALUE, query.getExactOnSingleWordQuery());
+        assertEquals("attribute", query.get("exactOnSingleWordQuery"));
         Query query2 = Query.parse(query.build());
-        assertEquals(query2.getExactOnSingleWordQuery(), query.getExactOnSingleWordQuery());
+        assertEquals(query.getExactOnSingleWordQuery(), query2.getExactOnSingleWordQuery());
     }
 
     @Test
@@ -714,7 +714,7 @@ public class QueryTest extends RobolectricTestCase {
 
         final Query.AlternativesAsExact[] array = {};
         query.setAlternativesAsExact(array);
-        assertArrayEquals(query.getAlternativesAsExact(), array);
+        assertArrayEquals(array, query.getAlternativesAsExact());
 
         query.setAlternativesAsExact(VALUES);
         assertArrayEquals(VALUES, query.getAlternativesAsExact());
@@ -743,6 +743,6 @@ public class QueryTest extends RobolectricTestCase {
         queryStr = query.build();
         assertTrue("The built query should contain 'aroundRadius=all', not _" + queryStr + "_.", queryStr.contains("aroundRadius=all"));
         Query query2 = Query.parse(query.build());
-        assertEquals(query2.getAroundRadius(), query.getAroundRadius());
+        assertEquals("The built query should be parsed and built successfully.", query.getAroundRadius(), query2.getAroundRadius());
     }
 }

--- a/algoliasearch/src/test/java/com/algolia/search/saas/places/PlacesClientTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/places/PlacesClientTest.java
@@ -60,7 +60,7 @@ public class PlacesClientTest extends RobolectricTestCase {
     }
 
     @Test
-    public void testSearchAsync() throws Exception {
+    public void searchAsync() throws Exception {
         PlacesQuery query = new PlacesQuery();
         query.setQuery("Paris");
         query.setType(PlacesQuery.Type.CITY);

--- a/algoliasearch/src/test/java/com/algolia/search/saas/places/PlacesQueryTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/places/PlacesQueryTest.java
@@ -42,7 +42,7 @@ public class PlacesQueryTest extends RobolectricTestCase  {
     // ----------------------------------------------------------------------
 
     @Test
-    public void test_hitsPerPage() {
+    public void hitsPerPage() {
         PlacesQuery query1 = new PlacesQuery();
         assertNull(query1.getHitsPerPage());
         query1.setHitsPerPage(50);
@@ -52,7 +52,7 @@ public class PlacesQueryTest extends RobolectricTestCase  {
     }
 
     @Test
-    public void test_query() {
+    public void query() {
         PlacesQuery query1 = new PlacesQuery();
         assertNull(query1.getQuery());
         query1.setQuery("San Francisco");
@@ -63,7 +63,7 @@ public class PlacesQueryTest extends RobolectricTestCase  {
     }
 
     @Test
-    public void test_highlightPreTag() {
+    public void highlightPreTag() {
         PlacesQuery query1 = new PlacesQuery();
         assertNull(query1.getHighlightPreTag());
         query1.setHighlightPreTag("<PRE[");
@@ -74,7 +74,7 @@ public class PlacesQueryTest extends RobolectricTestCase  {
     }
 
     @Test
-    public void test_highlightPostTag() {
+    public void highlightPostTag() {
         PlacesQuery query1 = new PlacesQuery();
         assertNull(query1.getHighlightPostTag());
         query1.setHighlightPostTag("]POST>");
@@ -85,7 +85,7 @@ public class PlacesQueryTest extends RobolectricTestCase  {
     }
 
     @Test
-    public void test_aroundRadius() {
+    public void aroundRadius() {
         PlacesQuery query1 = new PlacesQuery();
         assertNull(query1.getAroundRadius());
         query1.setAroundRadius(987);
@@ -96,7 +96,7 @@ public class PlacesQueryTest extends RobolectricTestCase  {
     }
 
     @Test
-    public void test_aroundRadius_all() {
+    public void aroundRadius_all() {
         final Integer VALUE = 3;
         PlacesQuery query = new PlacesQuery();
         assertNull("A new query should have a null aroundRadius.", query.getAroundRadius());
@@ -117,7 +117,7 @@ public class PlacesQueryTest extends RobolectricTestCase  {
     }
 
     @Test
-    public void test_aroundLatLngViaIP() {
+    public void aroundLatLngViaIP() {
         PlacesQuery query1 = new PlacesQuery();
         assertNull(query1.getAroundLatLngViaIP());
         query1.setAroundLatLngViaIP(true);
@@ -128,7 +128,7 @@ public class PlacesQueryTest extends RobolectricTestCase  {
     }
 
     @Test
-    public void test_aroundLatLng() {
+    public void aroundLatLng() {
         PlacesQuery query1 = new PlacesQuery();
         assertNull(query1.getAroundLatLng());
         query1.setAroundLatLng(new PlacesQuery.LatLng(89.76, -123.45));
@@ -139,7 +139,7 @@ public class PlacesQueryTest extends RobolectricTestCase  {
     }
 
     @Test
-    public void test_language() {
+    public void language() {
         PlacesQuery query1 = new PlacesQuery();
         assertNull(query1.getQuery());
         query1.setLanguage("en");
@@ -150,7 +150,7 @@ public class PlacesQueryTest extends RobolectricTestCase  {
     }
 
     @Test
-    public void test_countries() {
+    public void countries() {
         PlacesQuery query1 = new PlacesQuery();
         assertNull(query1.getCountries());
         query1.setCountries("de", "fr", "us");
@@ -161,7 +161,7 @@ public class PlacesQueryTest extends RobolectricTestCase  {
     }
 
     @Test
-    public void test_type() {
+    public void type() {
         PlacesQuery query1 = new PlacesQuery();
         assertNull(query1.getType());
         PlacesQuery query2;

--- a/algoliasearch/src/test/java/com/algolia/search/saas/places/PlacesQueryTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/places/PlacesQueryTest.java
@@ -46,9 +46,9 @@ public class PlacesQueryTest extends RobolectricTestCase  {
         PlacesQuery query1 = new PlacesQuery();
         assertNull(query1.getHitsPerPage());
         query1.setHitsPerPage(50);
-        assertEquals(query1.getHitsPerPage(), Integer.valueOf(50));
+        assertEquals(Integer.valueOf(50), query1.getHitsPerPage());
         PlacesQuery query2 = PlacesQuery.parse(query1.build());
-        assertEquals(query2.getHitsPerPage(), query1.getHitsPerPage());
+        assertEquals(query1.getHitsPerPage(), query2.getHitsPerPage());
     }
 
     @Test
@@ -56,10 +56,10 @@ public class PlacesQueryTest extends RobolectricTestCase  {
         PlacesQuery query1 = new PlacesQuery();
         assertNull(query1.getQuery());
         query1.setQuery("San Francisco");
-        assertEquals(query1.getQuery(), "San Francisco");
-        assertEquals(query1.get("query"), "San Francisco");
+        assertEquals("San Francisco", query1.getQuery());
+        assertEquals("San Francisco", query1.get("query"));
         PlacesQuery query2 = PlacesQuery.parse(query1.build());
-        assertEquals(query2.getQuery(), query1.getQuery());
+        assertEquals(query1.getQuery(), query2.getQuery());
     }
 
     @Test
@@ -67,10 +67,10 @@ public class PlacesQueryTest extends RobolectricTestCase  {
         PlacesQuery query1 = new PlacesQuery();
         assertNull(query1.getHighlightPreTag());
         query1.setHighlightPreTag("<PRE[");
-        assertEquals(query1.getHighlightPreTag(), "<PRE[");
-        assertEquals(query1.get("highlightPreTag"), "<PRE[");
+        assertEquals("<PRE[", query1.getHighlightPreTag());
+        assertEquals("<PRE[", query1.get("highlightPreTag"));
         PlacesQuery query2 = PlacesQuery.parse(query1.build());
-        assertEquals(query2.getHighlightPreTag(), query1.getHighlightPreTag());
+        assertEquals(query1.getHighlightPreTag(), query2.getHighlightPreTag());
     }
 
     @Test
@@ -78,10 +78,10 @@ public class PlacesQueryTest extends RobolectricTestCase  {
         PlacesQuery query1 = new PlacesQuery();
         assertNull(query1.getHighlightPostTag());
         query1.setHighlightPostTag("]POST>");
-        assertEquals(query1.getHighlightPostTag(), "]POST>");
-        assertEquals(query1.get("highlightPostTag"), "]POST>");
+        assertEquals("]POST>", query1.getHighlightPostTag());
+        assertEquals("]POST>", query1.get("highlightPostTag"));
         PlacesQuery query2 = PlacesQuery.parse(query1.build());
-        assertEquals(query2.getHighlightPostTag(), query1.getHighlightPostTag());
+        assertEquals(query1.getHighlightPostTag(), query2.getHighlightPostTag());
     }
 
     @Test
@@ -89,10 +89,10 @@ public class PlacesQueryTest extends RobolectricTestCase  {
         PlacesQuery query1 = new PlacesQuery();
         assertNull(query1.getAroundRadius());
         query1.setAroundRadius(987);
-        assertEquals(query1.getAroundRadius(), Integer.valueOf(987));
-        assertEquals(query1.get("aroundRadius"), "987");
+        assertEquals(Integer.valueOf(987), query1.getAroundRadius());
+        assertEquals("987", query1.get("aroundRadius"));
         PlacesQuery query2 = PlacesQuery.parse(query1.build());
-        assertEquals(query2.getAroundRadius(), query1.getAroundRadius());
+        assertEquals(query1.getAroundRadius(), query2.getAroundRadius());
     }
 
     @Test
@@ -121,10 +121,10 @@ public class PlacesQueryTest extends RobolectricTestCase  {
         PlacesQuery query1 = new PlacesQuery();
         assertNull(query1.getAroundLatLngViaIP());
         query1.setAroundLatLngViaIP(true);
-        assertEquals(query1.getAroundLatLngViaIP(), Boolean.TRUE);
-        assertEquals(query1.get("aroundLatLngViaIP"), "true");
+        assertEquals(Boolean.TRUE, query1.getAroundLatLngViaIP());
+        assertEquals("true", query1.get("aroundLatLngViaIP"));
         PlacesQuery query2 = PlacesQuery.parse(query1.build());
-        assertEquals(query2.getAroundLatLngViaIP(), query1.getAroundLatLngViaIP());
+        assertEquals(query1.getAroundLatLngViaIP(), query2.getAroundLatLngViaIP());
     }
 
     @Test
@@ -132,10 +132,10 @@ public class PlacesQueryTest extends RobolectricTestCase  {
         PlacesQuery query1 = new PlacesQuery();
         assertNull(query1.getAroundLatLng());
         query1.setAroundLatLng(new PlacesQuery.LatLng(89.76, -123.45));
-        assertEquals(query1.getAroundLatLng(), new PlacesQuery.LatLng(89.76, -123.45));
-        assertEquals(query1.get("aroundLatLng"), "89.76,-123.45");
+        assertEquals(new PlacesQuery.LatLng(89.76, -123.45), query1.getAroundLatLng());
+        assertEquals("89.76,-123.45", query1.get("aroundLatLng"));
         PlacesQuery query2 = PlacesQuery.parse(query1.build());
-        assertEquals(query2.getAroundLatLng(), query1.getAroundLatLng());
+        assertEquals(query1.getAroundLatLng(), query2.getAroundLatLng());
     }
 
     @Test
@@ -143,10 +143,10 @@ public class PlacesQueryTest extends RobolectricTestCase  {
         PlacesQuery query1 = new PlacesQuery();
         assertNull(query1.getQuery());
         query1.setLanguage("en");
-        assertEquals(query1.getLanguage(), "en");
-        assertEquals(query1.get("language"), "en");
+        assertEquals("en", query1.getLanguage());
+        assertEquals("en", query1.get("language"));
         PlacesQuery query2 = PlacesQuery.parse(query1.build());
-        assertEquals(query2.getQuery(), query1.getQuery());
+        assertEquals(query1.getQuery(), query2.getQuery());
     }
 
     @Test
@@ -167,46 +167,46 @@ public class PlacesQueryTest extends RobolectricTestCase  {
         PlacesQuery query2;
 
         query1.setType(PlacesQuery.Type.CITY);
-        assertEquals(query1.getType(), PlacesQuery.Type.CITY);
-        assertEquals(query1.get("type"), "city");
+        assertEquals(PlacesQuery.Type.CITY, query1.getType());
+        assertEquals("city", query1.get("type"));
         query2 = PlacesQuery.parse(query1.build());
-        assertEquals(query2.getType(), query1.getType());
+        assertEquals(query1.getType(), query2.getType());
 
         query1.setType(PlacesQuery.Type.COUNTRY);
-        assertEquals(query1.getType(), PlacesQuery.Type.COUNTRY);
-        assertEquals(query1.get("type"), "country");
+        assertEquals(PlacesQuery.Type.COUNTRY, query1.getType());
+        assertEquals("country", query1.get("type"));
         query2 = PlacesQuery.parse(query1.build());
-        assertEquals(query2.getType(), query1.getType());
+        assertEquals(query1.getType(), query2.getType());
 
         query1.setType(PlacesQuery.Type.ADDRESS);
-        assertEquals(query1.getType(), PlacesQuery.Type.ADDRESS);
-        assertEquals(query1.get("type"), "address");
+        assertEquals(PlacesQuery.Type.ADDRESS, query1.getType());
+        assertEquals("address", query1.get("type"));
         query2 = PlacesQuery.parse(query1.build());
-        assertEquals(query2.getType(), query1.getType());
+        assertEquals(query1.getType(), query2.getType());
 
         query1.setType(PlacesQuery.Type.BUS_STOP);
-        assertEquals(query1.getType(), PlacesQuery.Type.BUS_STOP);
-        assertEquals(query1.get("type"), "busStop");
+        assertEquals(PlacesQuery.Type.BUS_STOP, query1.getType());
+        assertEquals("busStop", query1.get("type"));
         query2 = PlacesQuery.parse(query1.build());
-        assertEquals(query2.getType(), query1.getType());
+        assertEquals(query1.getType(), query2.getType());
 
         query1.setType(PlacesQuery.Type.TRAIN_STATION);
-        assertEquals(query1.getType(), PlacesQuery.Type.TRAIN_STATION);
-        assertEquals(query1.get("type"), "trainStation");
+        assertEquals(PlacesQuery.Type.TRAIN_STATION, query1.getType());
+        assertEquals("trainStation", query1.get("type"));
         query2 = PlacesQuery.parse(query1.build());
-        assertEquals(query2.getType(), query1.getType());
+        assertEquals(query1.getType(), query2.getType());
 
         query1.setType(PlacesQuery.Type.TOWN_HALL);
-        assertEquals(query1.getType(), PlacesQuery.Type.TOWN_HALL);
-        assertEquals(query1.get("type"), "townhall");
+        assertEquals(PlacesQuery.Type.TOWN_HALL, query1.getType());
+        assertEquals("townhall", query1.get("type"));
         query2 = PlacesQuery.parse(query1.build());
-        assertEquals(query2.getType(), query1.getType());
+        assertEquals(query1.getType(), query2.getType());
 
         query1.setType(PlacesQuery.Type.AIRPORT);
-        assertEquals(query1.getType(), PlacesQuery.Type.AIRPORT);
-        assertEquals(query1.get("type"), "airport");
+        assertEquals(PlacesQuery.Type.AIRPORT, query1.getType());
+        assertEquals("airport", query1.get("type"));
         query2 = PlacesQuery.parse(query1.build());
-        assertEquals(query2.getType(), query1.getType());
+        assertEquals(query1.getType(), query2.getType());
 
         query1.set("type", "invalid");
         assertNull(query1.getType());

--- a/algoliasearch/src/test/java/com/algolia/search/saas/places/PlacesQueryTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/places/PlacesQueryTest.java
@@ -46,7 +46,7 @@ public class PlacesQueryTest extends RobolectricTestCase  {
         PlacesQuery query1 = new PlacesQuery();
         assertNull(query1.getHitsPerPage());
         query1.setHitsPerPage(50);
-        assertEquals(query1.getHitsPerPage(), new Integer(50));
+        assertEquals(query1.getHitsPerPage(), Integer.valueOf(50));
         PlacesQuery query2 = PlacesQuery.parse(query1.build());
         assertEquals(query2.getHitsPerPage(), query1.getHitsPerPage());
     }
@@ -89,7 +89,7 @@ public class PlacesQueryTest extends RobolectricTestCase  {
         PlacesQuery query1 = new PlacesQuery();
         assertNull(query1.getAroundRadius());
         query1.setAroundRadius(987);
-        assertEquals(query1.getAroundRadius(), new Integer(987));
+        assertEquals(query1.getAroundRadius(), Integer.valueOf(987));
         assertEquals(query1.get("aroundRadius"), "987");
         PlacesQuery query2 = PlacesQuery.parse(query1.build());
         assertEquals(query2.getAroundRadius(), query1.getAroundRadius());

--- a/algoliasearch/src/test/java/com/algolia/search/saas/places/PlacesQueryTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/places/PlacesQueryTest.java
@@ -43,56 +43,51 @@ public class PlacesQueryTest extends RobolectricTestCase  {
 
     @Test
     public void hitsPerPage() {
-        PlacesQuery query1 = new PlacesQuery();
-        assertNull(query1.getHitsPerPage());
-        query1.setHitsPerPage(50);
-        assertEquals(Integer.valueOf(50), query1.getHitsPerPage());
-        PlacesQuery query2 = PlacesQuery.parse(query1.build());
-        assertEquals(query1.getHitsPerPage(), query2.getHitsPerPage());
+        PlacesQuery query = new PlacesQuery();
+        assertNull(query.getHitsPerPage());
+        query.setHitsPerPage(50);
+        assertEquals(Integer.valueOf(50), query.getHitsPerPage());
+        assertEquals(query.getHitsPerPage(), PlacesQuery.parse(query.build()).getHitsPerPage());
     }
 
     @Test
     public void query() {
-        PlacesQuery query1 = new PlacesQuery();
-        assertNull(query1.getQuery());
-        query1.setQuery("San Francisco");
-        assertEquals("San Francisco", query1.getQuery());
-        assertEquals("San Francisco", query1.get("query"));
-        PlacesQuery query2 = PlacesQuery.parse(query1.build());
-        assertEquals(query1.getQuery(), query2.getQuery());
+        PlacesQuery query = new PlacesQuery();
+        assertNull(query.getQuery());
+        query.setQuery("San Francisco");
+        assertEquals("San Francisco", query.getQuery());
+        assertEquals("San Francisco", query.get("query"));
+        assertEquals(query.getQuery(), PlacesQuery.parse(query.build()).getQuery());
     }
 
     @Test
     public void highlightPreTag() {
-        PlacesQuery query1 = new PlacesQuery();
-        assertNull(query1.getHighlightPreTag());
-        query1.setHighlightPreTag("<PRE[");
-        assertEquals("<PRE[", query1.getHighlightPreTag());
-        assertEquals("<PRE[", query1.get("highlightPreTag"));
-        PlacesQuery query2 = PlacesQuery.parse(query1.build());
-        assertEquals(query1.getHighlightPreTag(), query2.getHighlightPreTag());
+        PlacesQuery query = new PlacesQuery();
+        assertNull(query.getHighlightPreTag());
+        query.setHighlightPreTag("<PRE[");
+        assertEquals("<PRE[", query.getHighlightPreTag());
+        assertEquals("<PRE[", query.get("highlightPreTag"));
+        assertEquals(query.getHighlightPreTag(), PlacesQuery.parse(query.build()).getHighlightPreTag());
     }
 
     @Test
     public void highlightPostTag() {
-        PlacesQuery query1 = new PlacesQuery();
-        assertNull(query1.getHighlightPostTag());
-        query1.setHighlightPostTag("]POST>");
-        assertEquals("]POST>", query1.getHighlightPostTag());
-        assertEquals("]POST>", query1.get("highlightPostTag"));
-        PlacesQuery query2 = PlacesQuery.parse(query1.build());
-        assertEquals(query1.getHighlightPostTag(), query2.getHighlightPostTag());
+        PlacesQuery query = new PlacesQuery();
+        assertNull(query.getHighlightPostTag());
+        query.setHighlightPostTag("]POST>");
+        assertEquals("]POST>", query.getHighlightPostTag());
+        assertEquals("]POST>", query.get("highlightPostTag"));
+        assertEquals(query.getHighlightPostTag(), PlacesQuery.parse(query.build()).getHighlightPostTag());
     }
 
     @Test
     public void aroundRadius() {
-        PlacesQuery query1 = new PlacesQuery();
-        assertNull(query1.getAroundRadius());
-        query1.setAroundRadius(987);
-        assertEquals(Integer.valueOf(987), query1.getAroundRadius());
-        assertEquals("987", query1.get("aroundRadius"));
-        PlacesQuery query2 = PlacesQuery.parse(query1.build());
-        assertEquals(query1.getAroundRadius(), query2.getAroundRadius());
+        PlacesQuery query = new PlacesQuery();
+        assertNull(query.getAroundRadius());
+        query.setAroundRadius(987);
+        assertEquals(Integer.valueOf(987), query.getAroundRadius());
+        assertEquals("987", query.get("aroundRadius"));
+        assertEquals(query.getAroundRadius(), PlacesQuery.parse(query.build()).getAroundRadius());
     }
 
     @Test
@@ -112,103 +107,90 @@ public class PlacesQueryTest extends RobolectricTestCase  {
 
         queryStr = query.build();
         assertTrue("The built query should contain 'aroundRadius=all', not _" + queryStr + "_.", queryStr.matches("aroundRadius=all"));
-        PlacesQuery query2 = PlacesQuery.parse(query.build());
-        assertEquals(query2.getAroundRadius(), query.getAroundRadius());
+        assertEquals(PlacesQuery.parse(query.build()).getAroundRadius(), query.getAroundRadius());
     }
 
     @Test
     public void aroundLatLngViaIP() {
-        PlacesQuery query1 = new PlacesQuery();
-        assertNull(query1.getAroundLatLngViaIP());
-        query1.setAroundLatLngViaIP(true);
-        assertEquals(Boolean.TRUE, query1.getAroundLatLngViaIP());
-        assertEquals("true", query1.get("aroundLatLngViaIP"));
-        PlacesQuery query2 = PlacesQuery.parse(query1.build());
-        assertEquals(query1.getAroundLatLngViaIP(), query2.getAroundLatLngViaIP());
+        PlacesQuery query = new PlacesQuery();
+        assertNull(query.getAroundLatLngViaIP());
+        query.setAroundLatLngViaIP(true);
+        assertEquals(Boolean.TRUE, query.getAroundLatLngViaIP());
+        assertEquals("true", query.get("aroundLatLngViaIP"));
+        assertEquals(query.getAroundLatLngViaIP(), PlacesQuery.parse(query.build()).getAroundLatLngViaIP());
     }
 
     @Test
     public void aroundLatLng() {
-        PlacesQuery query1 = new PlacesQuery();
-        assertNull(query1.getAroundLatLng());
-        query1.setAroundLatLng(new PlacesQuery.LatLng(89.76, -123.45));
-        assertEquals(new PlacesQuery.LatLng(89.76, -123.45), query1.getAroundLatLng());
-        assertEquals("89.76,-123.45", query1.get("aroundLatLng"));
-        PlacesQuery query2 = PlacesQuery.parse(query1.build());
-        assertEquals(query1.getAroundLatLng(), query2.getAroundLatLng());
+        PlacesQuery query = new PlacesQuery();
+        assertNull(query.getAroundLatLng());
+        query.setAroundLatLng(new PlacesQuery.LatLng(89.76, -123.45));
+        assertEquals(new PlacesQuery.LatLng(89.76, -123.45), query.getAroundLatLng());
+        assertEquals("89.76,-123.45", query.get("aroundLatLng"));
+        assertEquals(query.getAroundLatLng(), PlacesQuery.parse(query.build()).getAroundLatLng());
     }
 
     @Test
     public void language() {
-        PlacesQuery query1 = new PlacesQuery();
-        assertNull(query1.getQuery());
-        query1.setLanguage("en");
-        assertEquals("en", query1.getLanguage());
-        assertEquals("en", query1.get("language"));
-        PlacesQuery query2 = PlacesQuery.parse(query1.build());
-        assertEquals(query1.getQuery(), query2.getQuery());
+        PlacesQuery query = new PlacesQuery();
+        assertNull(query.getQuery());
+        query.setLanguage("en");
+        assertEquals("en", query.getLanguage());
+        assertEquals("en", query.get("language"));
+        assertEquals(query.getQuery(), PlacesQuery.parse(query.build()).getQuery());
     }
 
     @Test
     public void countries() {
-        PlacesQuery query1 = new PlacesQuery();
-        assertNull(query1.getCountries());
-        query1.setCountries("de", "fr", "us");
-        assertArrayEquals(query1.getCountries(), new String[]{ "de", "fr", "us" });
-        assertEquals(query1.get("countries"), "[\"de\",\"fr\",\"us\"]");
-        PlacesQuery query2 = PlacesQuery.parse(query1.build());
-        assertArrayEquals(query2.getCountries(), query1.getCountries());
+        PlacesQuery query = new PlacesQuery();
+        assertNull(query.getCountries());
+        query.setCountries("de", "fr", "us");
+        assertArrayEquals(query.getCountries(), new String[]{ "de", "fr", "us" });
+        assertEquals(query.get("countries"), "[\"de\",\"fr\",\"us\"]");
+        assertArrayEquals(PlacesQuery.parse(query.build()).getCountries(), query.getCountries());
     }
 
     @Test
     public void type() {
-        PlacesQuery query1 = new PlacesQuery();
-        assertNull(query1.getType());
-        PlacesQuery query2;
+        PlacesQuery query = new PlacesQuery();
+        assertNull(query.getType());
 
-        query1.setType(PlacesQuery.Type.CITY);
-        assertEquals(PlacesQuery.Type.CITY, query1.getType());
-        assertEquals("city", query1.get("type"));
-        query2 = PlacesQuery.parse(query1.build());
-        assertEquals(query1.getType(), query2.getType());
+        query.setType(PlacesQuery.Type.CITY);
+        assertEquals(PlacesQuery.Type.CITY, query.getType());
+        assertEquals("city", query.get("type"));
+        assertEquals(query.getType(), PlacesQuery.parse(query.build()).getType());
 
-        query1.setType(PlacesQuery.Type.COUNTRY);
-        assertEquals(PlacesQuery.Type.COUNTRY, query1.getType());
-        assertEquals("country", query1.get("type"));
-        query2 = PlacesQuery.parse(query1.build());
-        assertEquals(query1.getType(), query2.getType());
+        query.setType(PlacesQuery.Type.COUNTRY);
+        assertEquals(PlacesQuery.Type.COUNTRY, query.getType());
+        assertEquals("country", query.get("type"));
+        assertEquals(query.getType(), PlacesQuery.parse(query.build()).getType());
 
-        query1.setType(PlacesQuery.Type.ADDRESS);
-        assertEquals(PlacesQuery.Type.ADDRESS, query1.getType());
-        assertEquals("address", query1.get("type"));
-        query2 = PlacesQuery.parse(query1.build());
-        assertEquals(query1.getType(), query2.getType());
+        query.setType(PlacesQuery.Type.ADDRESS);
+        assertEquals(PlacesQuery.Type.ADDRESS, query.getType());
+        assertEquals("address", query.get("type"));
+        assertEquals(query.getType(), PlacesQuery.parse(query.build()).getType());
 
-        query1.setType(PlacesQuery.Type.BUS_STOP);
-        assertEquals(PlacesQuery.Type.BUS_STOP, query1.getType());
-        assertEquals("busStop", query1.get("type"));
-        query2 = PlacesQuery.parse(query1.build());
-        assertEquals(query1.getType(), query2.getType());
+        query.setType(PlacesQuery.Type.BUS_STOP);
+        assertEquals(PlacesQuery.Type.BUS_STOP, query.getType());
+        assertEquals("busStop", query.get("type"));
+        assertEquals(query.getType(), PlacesQuery.parse(query.build()).getType());
 
-        query1.setType(PlacesQuery.Type.TRAIN_STATION);
-        assertEquals(PlacesQuery.Type.TRAIN_STATION, query1.getType());
-        assertEquals("trainStation", query1.get("type"));
-        query2 = PlacesQuery.parse(query1.build());
-        assertEquals(query1.getType(), query2.getType());
+        query.setType(PlacesQuery.Type.TRAIN_STATION);
+        assertEquals(PlacesQuery.Type.TRAIN_STATION, query.getType());
+        assertEquals("trainStation", query.get("type"));
+        assertEquals(query.getType(), PlacesQuery.parse(query.build()).getType());
 
-        query1.setType(PlacesQuery.Type.TOWN_HALL);
-        assertEquals(PlacesQuery.Type.TOWN_HALL, query1.getType());
-        assertEquals("townhall", query1.get("type"));
-        query2 = PlacesQuery.parse(query1.build());
-        assertEquals(query1.getType(), query2.getType());
+        query.setType(PlacesQuery.Type.TOWN_HALL);
+        assertEquals(PlacesQuery.Type.TOWN_HALL, query.getType());
+        assertEquals("townhall", query.get("type"));
+        assertEquals(query.getType(), PlacesQuery.parse(query.build()).getType());
 
-        query1.setType(PlacesQuery.Type.AIRPORT);
-        assertEquals(PlacesQuery.Type.AIRPORT, query1.getType());
-        assertEquals("airport", query1.get("type"));
-        query2 = PlacesQuery.parse(query1.build());
-        assertEquals(query1.getType(), query2.getType());
+        query.setType(PlacesQuery.Type.AIRPORT);
+        assertEquals(PlacesQuery.Type.AIRPORT, query.getType());
+        assertEquals("airport", query.get("type"));
+        assertEquals(query.getType(), PlacesQuery.parse(query.build()).getType());
 
-        query1.set("type", "invalid");
-        assertNull(query1.getType());
+        query.set("type", "invalid");
+        assertNull(query.getType());
     }
 }


### PR DESCRIPTION
# Fixes
- Correct usage of `assert{,Array,Not}Equals`: most of the time `expected` and `equals` were inverted, **which produced misleading assert messages** (`expected "error" but got "valid"`).

# Correctness
- Check `Query.get(KEY)` for all tests, almost half were untested
- Check against `query1`'s content and not hardcoded value in analyticsTags (like we do in other tests)
- Use `getIndex` instead of deprecated `initIndex`

# Performance
- Use `String.contains` instead of `RegExp.match` to get the performance of the former when we don't need the powerfulness of the latter
- Use `Integer.valueOf()` instead of `new Integer()` to avoid creating multiple instances of same value
- Use `Collections.singletonList` instead of `Arrays.asList` when parameter is single value

# Cleanup
- Remove unnecessary `test`/`test_` prefixes
- Inline `query2` variables when unnecessary, rename `query1` to `query` when only `Query` in test
- Use diamond operator when possible
