### PR TITLE
New offline features

### DIFF
--- a/algoliasearch/src/main/java/com/algolia/search/saas/Index.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/Index.java
@@ -732,8 +732,11 @@ public class Index {
      */
     protected JSONObject getObject(String objectID, List<String> attributesToRetrieve) throws AlgoliaException {
         try {
-            String params = encodeAttributes(attributesToRetrieve, true);
-            return client.getRequest("/1/indexes/" + encodedIndexName + "/" + URLEncoder.encode(objectID, "UTF-8") + params, false);
+            String path = "/1/indexes/" + encodedIndexName + "/" + URLEncoder.encode(objectID, "UTF-8");
+            if (attributesToRetrieve != null) {
+                path += encodeAttributes(attributesToRetrieve, true); // includes the query separator (`?`)
+            }
+            return client.getRequest(path, false);
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }

--- a/algoliasearch/src/main/java/com/algolia/search/saas/Index.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/Index.java
@@ -399,12 +399,7 @@ public class Index {
      * @return A cancellable request.
      */
     public Request getObjectAsync(final @NonNull String objectID, @NonNull CompletionHandler completionHandler) {
-        return getClient().new AsyncTaskRequest(completionHandler) {
-            @NonNull
-            @Override protected JSONObject run() throws AlgoliaException {
-                return getObject(objectID);
-            }
-        }.start();
+        return getObjectAsync(objectID, null, completionHandler);
     }
 
     /**
@@ -432,12 +427,7 @@ public class Index {
      * @return A cancellable request.
      */
     public Request getObjectsAsync(final @NonNull List<String> objectIDs, @NonNull CompletionHandler completionHandler) {
-        return getClient().new AsyncTaskRequest(completionHandler) {
-            @NonNull
-            @Override protected JSONObject run() throws AlgoliaException {
-                return getObjects(objectIDs);
-            }
-        }.start();
+        return getObjectsAsync(objectIDs, null, completionHandler);
     }
 
     /**

--- a/algoliasearch/src/offline/java/com/algolia/search/saas/BootstrapListener.java
+++ b/algoliasearch/src/offline/java/com/algolia/search/saas/BootstrapListener.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2012-2016 Algolia
+ * http://www.algolia.com/
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.algolia.search.saas;
+
+import android.support.annotation.NonNull;
+
+/**
+ * Listener for events related to index bootstrapping.
+ *
+ * Notifications are sent on a per-index basis, but you may register the same listener for all indices.
+ * Notifications are sent on the main thread.
+ */
+public interface BootstrapListener
+{
+    /**
+     * Bootstrapping has just started.
+     *
+     * @param index The bootstrapping index.
+     */
+    public void bootstrapDidStart(@NonNull MirroredIndex index);
+
+    /**
+     * Bootstrapping has just finished.
+     *
+     * @param index The bootstrapping index.
+     * @param error Null if success, otherwise indicates the error.
+     */
+    public void bootstrapDidFinish(@NonNull MirroredIndex index, Throwable error);
+}

--- a/algoliasearch/src/offline/java/com/algolia/search/saas/BuildListener.java
+++ b/algoliasearch/src/offline/java/com/algolia/search/saas/BuildListener.java
@@ -27,7 +27,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 /**
- * Listener for events related to index bootstrapping.
+ * Listener for events related to index building.
  *
  * Notifications are sent on a per-index basis, but you may register the same listener for all indices.
  * Notifications are sent on the main thread.

--- a/algoliasearch/src/offline/java/com/algolia/search/saas/BuildListener.java
+++ b/algoliasearch/src/offline/java/com/algolia/search/saas/BuildListener.java
@@ -24,6 +24,7 @@
 package com.algolia.search.saas;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 /**
  * Listener for events related to index bootstrapping.
@@ -31,20 +32,20 @@ import android.support.annotation.NonNull;
  * Notifications are sent on a per-index basis, but you may register the same listener for all indices.
  * Notifications are sent on the main thread.
  */
-public interface BootstrapListener
+public interface BuildListener
 {
     /**
-     * Bootstrapping has just started.
+     * Build of the local index has just started.
      *
-     * @param index The bootstrapping index.
+     * @param index The index being built.
      */
-    public void bootstrapDidStart(@NonNull MirroredIndex index);
+    public void buildDidStart(@NonNull MirroredIndex index);
 
     /**
-     * Bootstrapping has just finished.
+     * Build of the local index has just finished.
      *
-     * @param index The bootstrapping index.
-     * @param error Null if success, otherwise indicates the error.
+     * @param index The index having been built.
+     * @param error `null` if success, otherwise indicates the error.
      */
-    public void bootstrapDidFinish(@NonNull MirroredIndex index, Throwable error);
+    public void buildDidFinish(@NonNull MirroredIndex index, @Nullable Throwable error);
 }

--- a/algoliasearch/src/offline/java/com/algolia/search/saas/FileUtils.java
+++ b/algoliasearch/src/offline/java/com/algolia/search/saas/FileUtils.java
@@ -26,6 +26,9 @@ package com.algolia.search.saas;
 import android.support.annotation.NonNull;
 
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * Various filesystem-related utilities.
@@ -48,5 +51,27 @@ class FileUtils
         }
         ok = ok && item.delete();
         return ok;
+    }
+
+    /**
+     * Write a stream of bytes to a file.
+     *
+     * @param destinationFile The file to be written to. The parent directory must exist. If the file already exists,
+     *                        it will be overwritten.
+     * @param content The bytes to write.
+     * @throws IOException if anything goes wrong.
+     */
+    public static void writeFile(@NonNull File destinationFile, @NonNull InputStream content) throws IOException {
+        byte[] buffer = new byte[64 * 1024]; // 64 kB buffer
+        FileOutputStream outputStream = new FileOutputStream(destinationFile);
+        try {
+            int bytesRead;
+            while ((bytesRead = content.read(buffer)) >= 0) {
+                outputStream.write(buffer, 0, bytesRead);
+            }
+        } finally {
+            content.close();
+            outputStream.close();
+        }
     }
 }

--- a/algoliasearch/src/offline/java/com/algolia/search/saas/MirroredIndex.java
+++ b/algoliasearch/src/offline/java/com/algolia/search/saas/MirroredIndex.java
@@ -616,6 +616,17 @@ public class MirroredIndex extends Index
     // ----------------------------------------------------------------------
 
     /**
+     * Test if this index has offline data on disk.
+     *
+     * **Warning:** This method is synchronous! It will block until completion.
+     *
+     * @return `true` if data exists on disk for this index, `false` otherwise.
+     */
+    public boolean hasOfflineData() {
+        return localIndex.exists();
+    }
+
+    /**
      * Bootstrap the local mirror with local data stored on the filesystem.
      *
      * **Note:** This method will do nothing if offline data is already available, making it safe to call at every

--- a/algoliasearch/src/offline/java/com/algolia/search/saas/MirroredIndex.java
+++ b/algoliasearch/src/offline/java/com/algolia/search/saas/MirroredIndex.java
@@ -618,7 +618,7 @@ public class MirroredIndex extends Index
      * @return `true` if data exists on disk for this index, `false` otherwise.
      */
     public boolean hasOfflineData() {
-        return localIndex.exists();
+        return getLocalIndex().exists();
     }
 
     /**

--- a/algoliasearch/src/offline/java/com/algolia/search/saas/MirroredIndex.java
+++ b/algoliasearch/src/offline/java/com/algolia/search/saas/MirroredIndex.java
@@ -1286,18 +1286,18 @@ public class MirroredIndex extends Index
     // BuildListener
 
     /**
-     * Add a listener for bootstrapping events.
+     * Add a listener for build events.
      * @param listener The listener to add.
      */
-    public void addBootstrapListener(@NonNull BuildListener listener) {
+    public void addBuildListener(@NonNull BuildListener listener) {
         buildListeners.add(listener);
     }
 
     /**
-     * Remove a listener for bootstrapping events.
+     * Remove a listener for build events.
      * @param listener The listener to remove.
      */
-    public void removeBootstrapListener(@NonNull BuildListener listener) {
+    public void removeBuildListener(@NonNull BuildListener listener) {
         buildListeners.remove(listener);
     }
 

--- a/algoliasearch/src/offline/java/com/algolia/search/saas/OfflineIndex.java
+++ b/algoliasearch/src/offline/java/com/algolia/search/saas/OfflineIndex.java
@@ -818,6 +818,17 @@ public class OfflineIndex {
         return new WriteTransaction();
     }
 
+    /**
+     * Test if this index has offline data on disk.
+     *
+     * **Warning:** This method is synchronous! It will block until completion.
+     *
+     * @return `true` if data exists on disk for this index, `false` otherwise.
+     */
+    public boolean hasOfflineData() {
+        return localIndex.exists();
+    }
+
     // ----------------------------------------------------------------------
     // Helpers
     // ----------------------------------------------------------------------

--- a/algoliasearch/src/test/java/com/algolia/search/saas/IndexTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/IndexTest.java
@@ -93,8 +93,8 @@ public class IndexTest extends RobolectricTestCase {
             client.deleteIndex(originalIndexName);
 
             originalObjects = new ArrayList<>();
-            originalObjects.add(new JSONObject("{\"city\": \"San Francisco\"}"));
-            originalObjects.add(new JSONObject("{\"city\": \"San José\"}"));
+            originalObjects.add(new JSONObject("{\"city\": \"San Francisco\", \"state\": \"CA\"}"));
+            originalObjects.add(new JSONObject("{\"city\": \"San José\", \"state\": \"CA\"}"));
 
             JSONObject task = originalIndex.addObjects(new JSONArray(originalObjects));
             originalIndex.waitTask(task.getString("taskID"));
@@ -399,12 +399,12 @@ public class IndexTest extends RobolectricTestCase {
 
     @Test
     public void getObjectWithAttributesToRetrieveAsync() throws Exception {
-        List<String> attributesToRetrieve = new ArrayList<>();
-        attributesToRetrieve.add("objectID");
+        List<String> attributesToRetrieve = Arrays.asList("objectID", "state");
         index.getObjectAsync(ids.get(0), attributesToRetrieve, new AssertCompletionHandler() {
             @Override public void doRequestCompleted(JSONObject content, AlgoliaException error) {
                 if (error == null) {
                     assertTrue("Object has unexpected objectId", content.optString("objectID").equals(ids.get(0)));
+                    assertTrue("Object is missing expected 'state' attribute", content.has("state"));
                     assertFalse("Object has unexpected 'city' attribute", content.has("city"));
                 } else {
                     fail(error.getMessage());

--- a/algoliasearch/src/test/java/com/algolia/search/saas/IndexTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/IndexTest.java
@@ -430,6 +430,24 @@ public class IndexTest extends RobolectricTestCase {
     }
 
     @Test
+    public void getObjectsWithAttributesToRetrieveAsync() throws Exception {
+        List<String> attributesToRetrieve = new ArrayList<>();
+        attributesToRetrieve.add("objectID");
+        index.getObjectsAsync(ids, attributesToRetrieve, new AssertCompletionHandler() {
+            @Override public void doRequestCompleted(JSONObject content, AlgoliaException error) {
+                if (error == null) {
+                    JSONArray res = content.optJSONArray("results");
+                    assertNotNull(res);
+                    assertTrue("Object has unexpected objectId", res.optJSONObject(0).optString("objectID").equals(ids.get(0)));
+                    assertFalse("Object has unexpected 'city' attribute", res.optJSONObject(1).has("city"));
+                } else {
+                    fail(error.getMessage());
+                }
+            }
+        });
+    }
+
+    @Test
     public void waitTaskAsync() throws Exception {
         index.addObjectAsync(new JSONObject("{\"city\": \"New York\"}"), new AssertCompletionHandler() {
             @Override public void doRequestCompleted(JSONObject content, AlgoliaException error) {

--- a/algoliasearch/src/testOffline/java/com/algolia/search/saas/MirroredIndexTest.java
+++ b/algoliasearch/src/testOffline/java/com/algolia/search/saas/MirroredIndexTest.java
@@ -370,7 +370,6 @@ public class MirroredIndexTest extends OfflineTestBase  {
         });
     }
 
-
     @Test
     public void testGetObject() {
         final CountDownLatch signal = new CountDownLatch(4);

--- a/algoliasearch/src/testOffline/java/com/algolia/search/saas/MirroredIndexTest.java
+++ b/algoliasearch/src/testOffline/java/com/algolia/search/saas/MirroredIndexTest.java
@@ -32,6 +32,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -40,6 +41,7 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
@@ -308,6 +310,60 @@ public class MirroredIndexTest extends OfflineTestBase  {
                         signal.countDown();
                     }
                 });
+            }
+        });
+    }
+
+    @Test
+    public void testGetObjects() {
+        final CountDownLatch signal = new CountDownLatch(4);
+
+        // Populate the online index & sync the offline mirror.
+        final MirroredIndex index = client.getIndex(Helpers.safeIndexName(Helpers.getMethodName()));
+        sync(index, new SyncCompletionHandler() {
+            @Override
+            public void syncCompleted(@Nullable Throwable error) {
+                assertNull(error);
+
+                // Query the online index explicitly.
+                index.getObjectsOnlineAsync(Arrays.asList("1"), new AssertCompletionHandler() {
+                    @Override
+                    public void doRequestCompleted(JSONObject content, AlgoliaException error) {
+                        assertNull(error);
+                        assertNotNull(content.optJSONArray("results"));
+                        assertEquals(1, content.optJSONArray("results").length());
+                        assertEquals("remote", content.optString("origin"));
+
+                        // Test offline fallback.
+                        client.setReadHosts("unknown.algolia.com");
+                        index.setRequestStrategy(MirroredIndex.Strategy.FALLBACK_ON_FAILURE);
+                        index.getObjectsAsync(Arrays.asList("1", "2", "3"), new AssertCompletionHandler() {
+                            @Override
+                            public void doRequestCompleted(JSONObject content, AlgoliaException error) {
+                                assertNull(error);
+                                assertNotNull(content.optJSONArray("results"));
+                                assertEquals(3, content.optJSONArray("results").length());
+                                assertEquals("local", content.optString("origin"));
+                                signal.countDown();
+                            }
+                        });
+                        signal.countDown();
+                    }
+                });
+
+                // Query the offline index explicitly.
+                index.getObjectsOfflineAsync(Arrays.asList("1", "2"), new AssertCompletionHandler() {
+                    @Override
+                    public void doRequestCompleted(JSONObject content, AlgoliaException error) {
+                        assertNull(error);
+                        assertNotNull(content.optJSONArray("results"));
+                        assertEquals(2, content.optJSONArray("results").length());
+                        assertEquals("local", content.optString("origin"));
+                        signal.countDown();
+                    }
+                });
+
+                signal.countDown();
             }
         });
     }

--- a/algoliasearch/src/testOffline/res/raw/objects.json
+++ b/algoliasearch/src/testOffline/res/raw/objects.json
@@ -1,0 +1,37 @@
+[
+    {
+        "objectID": "1",
+        "name": "Snoopy",
+        "kind": [ "dog", "animal" ],
+        "born": 1967,
+        "series": "Peanuts"
+    },
+    {
+        "objectID": "2",
+        "name": "Woodstock",
+        "kind": ["bird", "animal" ],
+        "born": 1970,
+        "series": "Peanuts"
+    },
+    {
+        "objectID": "3",
+        "name": "Charlie Brown",
+        "kind": [ "human" ],
+        "born": 1950,
+        "series": "Peanuts"
+    },
+    {
+        "objectID": "4",
+        "name": "Hobbes",
+        "kind": [ "tiger", "animal", "teddy" ],
+        "born": 1985,
+        "series": "Calvin & Hobbes"
+    },
+    {
+        "objectID": "5",
+        "name": "Calvin",
+        "kind": [ "human" ],
+        "born": 1985,
+        "series": "Calvin & Hobbes"
+    }
+]

--- a/algoliasearch/src/testOffline/res/raw/settings.json
+++ b/algoliasearch/src/testOffline/res/raw/settings.json
@@ -1,0 +1,10 @@
+{
+    "attributesToIndex": [
+        "name",
+        "kind",
+        "series"
+    ],
+    "attributesForFaceting": [
+        "kind"
+    ]
+}


### PR DESCRIPTION
- Manually build a `MirroredIndex` or an `OfflineIndex` from local files or raw resources. Combined with a new `hasOfflineData()` getter, this allows **bootstrapping** a mirrored index before the first sync.

- Get individual objects directly from the local mirror of a `MirroredIndex`, or use the same fallback policy as search.
