### PR TITLE
Support offline search for facet values

### DIFF
--- a/algoliasearch/build-offline.gradle
+++ b/algoliasearch/build-offline.gradle
@@ -40,7 +40,7 @@ android {
 }
 
 dependencies {
-    offlineCompile "com.algolia:algoliasearch-offline-core-android:1.0.1"
+    offlineCompile "com.algolia:algoliasearch-offline-core-android:1.1"
 }
 
 

--- a/algoliasearch/build-offline.gradle
+++ b/algoliasearch/build-offline.gradle
@@ -40,7 +40,7 @@ android {
 }
 
 dependencies {
-    offlineCompile "com.algolia:algoliasearch-offline-core-android:1.1"
+    offlineCompile "com.algolia:algoliasearch-offline-core-android:1.1.0"
 }
 
 

--- a/algoliasearch/src/main/java/com/algolia/search/saas/Index.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/Index.java
@@ -189,7 +189,7 @@ public class Index {
      * @param handler   A Completion handler that will be notified of the request's outcome.
      * @return A cancellable request.
      */
-    public Request searchForFacetValues(@NonNull String facetName, @NonNull String text, @NonNull final CompletionHandler handler) throws AlgoliaException {
+    public Request searchForFacetValues(@NonNull String facetName, @NonNull String text, @NonNull final CompletionHandler handler) {
         return searchForFacetValues(facetName, text, null, handler);
     }
 
@@ -202,7 +202,7 @@ public class Index {
      * @param handler   A Completion handler that will be notified of the request's outcome.
      * @return A cancellable request.
      */
-    public Request searchForFacetValues(@NonNull String facetName, @NonNull String facetText, @Nullable Query query, @NonNull final CompletionHandler handler) throws AlgoliaException {
+    public Request searchForFacetValues(@NonNull String facetName, @NonNull String facetText, @Nullable Query query, @NonNull final CompletionHandler handler) {
         try {
             final String path = "/1/indexes/" + getEncodedIndexName() + "/facets/" + URLEncoder.encode(facetName, "UTF-8") + "/query";
             final Query params = (query != null ? new Query(query) : new Query());
@@ -218,7 +218,7 @@ public class Index {
                 }
             }.start();
         } catch (UnsupportedEncodingException | JSONException e) {
-            throw new AlgoliaException(e.getMessage());
+            throw new RuntimeException(e); // should never happen
         }
     }
 

--- a/algoliasearch/src/offline/java/com/algolia/search/saas/OfflineIndex.java
+++ b/algoliasearch/src/offline/java/com/algolia/search/saas/OfflineIndex.java
@@ -390,6 +390,28 @@ public class OfflineIndex {
         return OfflineClient.parseSearchResults(localIndex.browse(query.build()));
     }
 
+    /**
+     * Search for facet values (asynchronously).
+     * Same parameters as {@link Index#searchForFacetValues(String, String, Query, CompletionHandler)}.
+     */
+    public Request searchForFacetValuesAsync(final @NonNull String facetName, final @NonNull String facetQuery, @Nullable Query query, @NonNull CompletionHandler completionHandler) {
+        final Query queryCopy = query != null ? new Query(query) : null;
+        return getClient().new AsyncTaskRequest(completionHandler) {
+            @NonNull
+            @Override
+            protected JSONObject run() throws AlgoliaException {
+                return searchForFacetValuesSync(facetName, facetQuery, queryCopy);
+            }
+        }.start();
+    }
+
+    /**
+     * Search for facet values (synchronously).
+     */
+    private JSONObject searchForFacetValuesSync(@NonNull String facetName, @NonNull String facetQuery, @Nullable Query query) throws AlgoliaException {
+        return OfflineClient.parseSearchResults(localIndex.searchForFacetValues(facetName, facetQuery, query != null ? query.build() : null));
+    }
+
     // ----------------------------------------------------------------------
     // Transaction management
     // ----------------------------------------------------------------------

--- a/algoliasearch/src/testOffline/java/com/algolia/search/saas/OfflineTestBase.java
+++ b/algoliasearch/src/testOffline/java/com/algolia/search/saas/OfflineTestBase.java
@@ -87,6 +87,22 @@ public abstract class OfflineTestBase extends RobolectricTestCase {
         }
     }
 
+    /** Index settings. */
+    protected static JSONObject settings = new JSONObject();
+    static {
+        try {
+            settings
+                .put("searchableAttributes", new JSONArray()
+                    .put("name").put("kind").put("series")
+                )
+                .put("attributesForFaceting", new JSONArray().put("searchable(series)")
+            );
+        }
+        catch (JSONException e) {
+            throw new RuntimeException(e); // should never happen
+        }
+    }
+
     @Override
     public void setUp() throws Exception {
         super.setUp();


### PR DESCRIPTION
Implement offline search for facet values, just like for regular search:

- on `MirroredIndex` with request strategy
- on `OfflineIndex` for pure offline request

Requires Offline Core 1.1.0, which is out now.
