### PR TITLE
Fix the case when header is bigger than 8KB

### DIFF
--- a/algoliasearch/src/test/java/com/algolia/search/saas/Helpers.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/Helpers.java
@@ -24,6 +24,7 @@
 package com.algolia.search.saas;
 
 import android.support.annotation.NonNull;
+import java.util.Arrays;
 
 public class Helpers {
     public static String app_id = "%ALGOLIA_APPLICATION_ID%";
@@ -33,6 +34,13 @@ public class Helpers {
     public static String job_number = "%JOB_NUMBER%";
 
     public static int wait = 30;
+
+    static String getLongApiKey() {
+        int n = 65000;
+        char[] chars = new char[n];
+        Arrays.fill(chars, 'c');
+        return new String(chars);
+    }
 
     static String safeIndexName(String name) {
         if (job_number.matches("\\d+\\.\\d+")) {


### PR DESCRIPTION
When the header of the request is too big, we get a 494 header too large error. 

The header becomes too large when we generate a very large secure api key that is mixed with query parameters. 

A temporary fix is to put the apikey in the body instead of the header for search requests