### PR TITLE
feat(request-options): Add support for per-request options

### DIFF
--- a/algoliasearch/src/main/java/com/algolia/search/saas/Client.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/Client.java
@@ -164,15 +164,44 @@ public class Client extends AbstractClient {
     /**
      * List existing indexes.
      *
+     * @param requestOptions Request-specific options.
      * @param completionHandler The listener that will be notified of the request's outcome.
      * @return A cancellable request.
      */
-    public Request listIndexesAsync(@NonNull CompletionHandler completionHandler) {
+    public Request listIndexesAsync(@Nullable final RequestOptions requestOptions, @NonNull CompletionHandler completionHandler) {
         return new AsyncTaskRequest(completionHandler) {
             @NonNull
             @Override
             protected JSONObject run() throws AlgoliaException {
-                return listIndexes();
+                return listIndexes(requestOptions);
+            }
+        }.start();
+    }
+
+    /**
+     * List existing indexes.
+     *
+     * @param completionHandler The listener that will be notified of the request's outcome.
+     * @return A cancellable request.
+     */
+    public Request listIndexesAsync(@NonNull CompletionHandler completionHandler) {
+        return listIndexesAsync(/* requestOptions: */ null, completionHandler);
+    }
+
+    /**
+     * Delete an index.
+     *
+     * @param indexName Name of index to delete.
+     * @param requestOptions Request-specific options.
+     * @param completionHandler The listener that will be notified of the request's outcome.
+     * @return A cancellable request.
+     */
+    public Request deleteIndexAsync(final @NonNull String indexName, @Nullable final RequestOptions requestOptions, CompletionHandler completionHandler) {
+        return new AsyncTaskRequest(completionHandler) {
+            @NonNull
+            @Override
+            protected JSONObject run() throws AlgoliaException {
+                return deleteIndex(indexName, requestOptions);
             }
         }.start();
     }
@@ -185,11 +214,26 @@ public class Client extends AbstractClient {
      * @return A cancellable request.
      */
     public Request deleteIndexAsync(final @NonNull String indexName, CompletionHandler completionHandler) {
+        return deleteIndexAsync(indexName, /* requestOptions: */ null, completionHandler);
+    }
+
+    /**
+     * Move an existing index.
+     * If the destination index already exists, its specific API keys will be preserved and the source index specific
+     * API keys will be added.
+     *
+     * @param srcIndexName Name of index to move.
+     * @param dstIndexName The new index name.
+     * @param requestOptions Request-specific options.
+     * @param completionHandler The listener that will be notified of the request's outcome.
+     * @return A cancellable request.
+     */
+    public Request moveIndexAsync(final @NonNull String srcIndexName, final @NonNull String dstIndexName, @Nullable final RequestOptions requestOptions, CompletionHandler completionHandler) {
         return new AsyncTaskRequest(completionHandler) {
             @NonNull
             @Override
             protected JSONObject run() throws AlgoliaException {
-                return deleteIndex(indexName);
+                return moveIndex(srcIndexName, dstIndexName, requestOptions);
             }
         }.start();
     }
@@ -205,11 +249,26 @@ public class Client extends AbstractClient {
      * @return A cancellable request.
      */
     public Request moveIndexAsync(final @NonNull String srcIndexName, final @NonNull String dstIndexName, CompletionHandler completionHandler) {
+        return moveIndexAsync(srcIndexName, dstIndexName, /* requestOptions: */ null, completionHandler);
+    }
+
+    /**
+     * Copy an existing index.
+     * If the destination index already exists, its specific API keys will be preserved and the source index specific
+     * API keys will be added.
+     *
+     * @param srcIndexName Name of index to copy.
+     * @param dstIndexName The new index name.
+     * @param requestOptions Request-specific options.
+     * @param completionHandler The listener that will be notified of the request's outcome.
+     * @return A cancellable request.
+     */
+    public Request copyIndexAsync(final @NonNull String srcIndexName, final @NonNull String dstIndexName, @Nullable final RequestOptions requestOptions, CompletionHandler completionHandler) {
         return new AsyncTaskRequest(completionHandler) {
             @NonNull
             @Override
             protected JSONObject run() throws AlgoliaException {
-                return moveIndex(srcIndexName, dstIndexName);
+                return copyIndex(srcIndexName, dstIndexName, requestOptions);
             }
         }.start();
     }
@@ -225,13 +284,7 @@ public class Client extends AbstractClient {
      * @return A cancellable request.
      */
     public Request copyIndexAsync(final @NonNull String srcIndexName, final @NonNull String dstIndexName, CompletionHandler completionHandler) {
-        return new AsyncTaskRequest(completionHandler) {
-            @NonNull
-            @Override
-            protected JSONObject run() throws AlgoliaException {
-                return copyIndex(srcIndexName, dstIndexName);
-            }
-        }.start();
+        return copyIndexAsync(srcIndexName, dstIndexName, /* requestOptions: */ null, completionHandler);
     }
 
     /**
@@ -259,15 +312,46 @@ public class Client extends AbstractClient {
      *
      * @param queries The queries to run.
      * @param strategy The strategy to use.
+     * @param requestOptions Request-specific options.
      * @param completionHandler The listener that will be notified of the request's outcome.
      * @return A cancellable request.
      */
-    public Request multipleQueriesAsync(final @NonNull List<IndexQuery> queries, final MultipleQueriesStrategy strategy, @NonNull CompletionHandler completionHandler) {
+    public Request multipleQueriesAsync(final @NonNull List<IndexQuery> queries, final MultipleQueriesStrategy strategy, @Nullable final RequestOptions requestOptions, @NonNull CompletionHandler completionHandler) {
         return new AsyncTaskRequest(completionHandler) {
             @NonNull
             @Override
             protected JSONObject run() throws AlgoliaException {
-                return multipleQueries(queries, strategy == null ? null : strategy.toString());
+                return multipleQueries(queries, strategy == null ? null : strategy.toString(), requestOptions);
+            }
+        }.start();
+    }
+
+    /**
+     * Run multiple queries, potentially targeting multiple indexes, with one API call.
+     *
+     * @param queries The queries to run.
+     * @param strategy The strategy to use.
+     * @param completionHandler The listener that will be notified of the request's outcome.
+     * @return A cancellable request.
+     */
+    public Request multipleQueriesAsync(final @NonNull List<IndexQuery> queries, final MultipleQueriesStrategy strategy, @NonNull CompletionHandler completionHandler) {
+        return multipleQueriesAsync(queries, strategy, /* requestOptions: */ null, completionHandler);
+    }
+
+    /**
+     * Batch operations.
+     *
+     * @param operations List of operations.
+     * @param requestOptions Request-specific options.
+     * @param completionHandler The listener that will be notified of the request's outcome.
+     * @return A cancellable request.
+     */
+    public Request batchAsync(final @NonNull JSONArray operations, @Nullable final RequestOptions requestOptions, CompletionHandler completionHandler) {
+        return new AsyncTaskRequest(completionHandler) {
+            @NonNull
+            @Override
+            protected JSONObject run() throws AlgoliaException {
+                return batch(operations, requestOptions);
             }
         }.start();
     }
@@ -280,13 +364,7 @@ public class Client extends AbstractClient {
      * @return A cancellable request.
      */
     public Request batchAsync(final @NonNull JSONArray operations, CompletionHandler completionHandler) {
-        return new AsyncTaskRequest(completionHandler) {
-            @NonNull
-            @Override
-            protected JSONObject run() throws AlgoliaException {
-                return batch(operations);
-            }
-        }.start();
+        return batchAsync(operations, /* requestOptions: */ null, completionHandler);
     }
 
     // ----------------------------------------------------------------------
@@ -296,23 +374,25 @@ public class Client extends AbstractClient {
     /**
      * List all existing indexes
      *
+     * @param requestOptions Request-specific options.
      * @return a JSON Object in the form:
      * { "items": [ {"name": "contacts", "createdAt": "2013-01-18T15:33:13.556Z"},
      *              {"name": "notes", "createdAt": "2013-01-18T15:33:13.556Z"}]}
      */
-    protected JSONObject listIndexes() throws AlgoliaException {
-        return getRequest("/1/indexes/", false);
+    protected JSONObject listIndexes(@Nullable RequestOptions requestOptions) throws AlgoliaException {
+        return getRequest("/1/indexes/", false, requestOptions);
     }
 
     /**
      * Delete an index
      *
+     * @param requestOptions Request-specific options.
      * @param indexName the name of index to delete
      * @return an object containing a "deletedAt" attribute
      */
-    protected JSONObject deleteIndex(String indexName) throws AlgoliaException {
+    protected JSONObject deleteIndex(String indexName, @Nullable RequestOptions requestOptions) throws AlgoliaException {
         try {
-            return deleteRequest("/1/indexes/" + URLEncoder.encode(indexName, "UTF-8"));
+            return deleteRequest("/1/indexes/" + URLEncoder.encode(indexName, "UTF-8"), requestOptions);
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }
@@ -323,13 +403,14 @@ public class Client extends AbstractClient {
      *
      * @param srcIndexName the name of index to copy.
      * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination will be overriten if it already exist).
+     * @param requestOptions Request-specific options.
      */
-    protected JSONObject moveIndex(String srcIndexName, String dstIndexName) throws AlgoliaException {
+    protected JSONObject moveIndex(String srcIndexName, String dstIndexName, @Nullable RequestOptions requestOptions) throws AlgoliaException {
         try {
             JSONObject content = new JSONObject();
             content.put("operation", "move");
             content.put("destination", dstIndexName);
-            return postRequest("/1/indexes/" + URLEncoder.encode(srcIndexName, "UTF-8") + "/operation", content.toString(), false);
+            return postRequest("/1/indexes/" + URLEncoder.encode(srcIndexName, "UTF-8") + "/operation", content.toString(), false, requestOptions);
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         } catch (JSONException e) {
@@ -342,13 +423,14 @@ public class Client extends AbstractClient {
      *
      * @param srcIndexName the name of index to copy.
      * @param dstIndexName the new index name that will contains a copy of srcIndexName (destination will be overriten if it already exist).
+     * @param requestOptions Request-specific options.
      */
-    protected JSONObject copyIndex(String srcIndexName, String dstIndexName) throws AlgoliaException {
+    protected JSONObject copyIndex(String srcIndexName, String dstIndexName, @Nullable RequestOptions requestOptions) throws AlgoliaException {
         try {
             JSONObject content = new JSONObject();
             content.put("operation", "copy");
             content.put("destination", dstIndexName);
-            return postRequest("/1/indexes/" + URLEncoder.encode(srcIndexName, "UTF-8") + "/operation", content.toString(), false);
+            return postRequest("/1/indexes/" + URLEncoder.encode(srcIndexName, "UTF-8") + "/operation", content.toString(), false, requestOptions);
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         } catch (JSONException e) {
@@ -356,7 +438,7 @@ public class Client extends AbstractClient {
         }
     }
 
-    protected JSONObject multipleQueries(List<IndexQuery> queries, String strategy) throws AlgoliaException {
+    protected JSONObject multipleQueries(List<IndexQuery> queries, String strategy, @Nullable RequestOptions requestOptions) throws AlgoliaException {
         try {
             JSONArray requests = new JSONArray();
             for (IndexQuery indexQuery : queries) {
@@ -370,7 +452,7 @@ public class Client extends AbstractClient {
             if (strategy != null) {
                 body.put("strategy", strategy);
             }
-            return postRequest(path, body.toString(), true);
+            return postRequest(path, body.toString(), true, requestOptions);
         } catch (JSONException e) {
             throw new AlgoliaException(e.getMessage());
         }
@@ -380,13 +462,14 @@ public class Client extends AbstractClient {
      * Custom batch
      *
      * @param actions the array of actions
+     * @param requestOptions Request-specific options.
      * @throws AlgoliaException if the response is not valid json
      */
-    protected JSONObject batch(JSONArray actions) throws AlgoliaException {
+    protected JSONObject batch(JSONArray actions, @Nullable RequestOptions requestOptions) throws AlgoliaException {
         try {
             JSONObject content = new JSONObject();
             content.put("requests", actions);
-            return postRequest("/1/indexes/*/batch", content.toString(), false);
+            return postRequest("/1/indexes/*/batch", content.toString(), false, requestOptions);
         } catch (JSONException e) {
             throw new AlgoliaException(e.getMessage());
         }

--- a/algoliasearch/src/main/java/com/algolia/search/saas/Index.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/Index.java
@@ -105,6 +105,27 @@ public class Index {
     // Public operations
     // ----------------------------------------------------------------------
 
+    // Search
+    // ------
+
+    /**
+     * Search inside this index (asynchronously).
+     *
+     * @param query             Search parameters. May be null to use an empty query.
+     * @param requestOptions Request-specific options.
+     * @param completionHandler The listener that will be notified of the request's outcome.
+     * @return A cancellable request.
+     */
+    public Request searchAsync(@Nullable Query query, @Nullable final RequestOptions requestOptions, @Nullable CompletionHandler completionHandler) {
+        final Query queryCopy = query != null ? new Query(query) : new Query();
+        return getClient().new AsyncTaskRequest(completionHandler) {
+            @NonNull
+            @Override protected JSONObject run() throws AlgoliaException {
+                return search(queryCopy, requestOptions);
+            }
+        }.start();
+    }
+
     /**
      * Search inside this index (asynchronously).
      *
@@ -113,13 +134,18 @@ public class Index {
      * @return A cancellable request.
      */
     public Request searchAsync(@Nullable Query query, @Nullable CompletionHandler completionHandler) {
-        final Query queryCopy = query != null ? new Query(query) : new Query();
-        return getClient().new AsyncTaskRequest(completionHandler) {
-            @NonNull
-            @Override protected JSONObject run() throws AlgoliaException {
-                return search(queryCopy);
-            }
-        }.start();
+        return searchAsync(query, /* requestOptions: */ null, completionHandler);
+    }
+
+    /**
+     * Search inside this index (synchronously).
+     *
+     * @param query Search parameters.
+     * @param requestOptions Request-specific options.
+     * @return Search results.
+     */
+    public JSONObject searchSync(@Nullable Query query, @Nullable RequestOptions requestOptions) throws AlgoliaException {
+        return search(query, requestOptions);
     }
 
     /**
@@ -128,7 +154,31 @@ public class Index {
      * @return Search results.
      */
     public JSONObject searchSync(@Nullable Query query) throws AlgoliaException {
-        return search(query);
+        return searchSync(query, /* requestOptions: */ null);
+    }
+
+    /**
+     * Run multiple queries on this index with one API call.
+     * A variant of {@link Client#multipleQueriesAsync(List, Client.MultipleQueriesStrategy, CompletionHandler)}
+     * where the targeted index is always the receiver.
+     *
+     * @param queries           The queries to run.
+     * @param strategy          The strategy to use.
+     * @param requestOptions Request-specific options.
+     * @param completionHandler The listener that will be notified of the request's outcome.
+     * @return A cancellable request.
+     */
+    public Request multipleQueriesAsync(final @NonNull List<Query> queries, final Client.MultipleQueriesStrategy strategy, @Nullable final RequestOptions requestOptions, @NonNull CompletionHandler completionHandler) {
+        final List<Query> queriesCopy = new ArrayList<>(queries.size());
+        for (Query query : queries) {
+            queriesCopy.add(new Query(query));
+        }
+        return getClient().new AsyncTaskRequest(completionHandler) {
+            @NonNull
+            @Override protected JSONObject run() throws AlgoliaException {
+                return multipleQueries(queriesCopy, strategy == null ? null : strategy.toString(), requestOptions);
+            }
+        }.start();
     }
 
     /**
@@ -142,25 +192,37 @@ public class Index {
      * @return A cancellable request.
      */
     public Request multipleQueriesAsync(final @NonNull List<Query> queries, final Client.MultipleQueriesStrategy strategy, @NonNull CompletionHandler completionHandler) {
-        final List<Query> queriesCopy = new ArrayList<>(queries.size());
-        for (Query query : queries) {
-            queriesCopy.add(new Query(query));
-        }
-        return getClient().new AsyncTaskRequest(completionHandler) {
-            @NonNull
-            @Override protected JSONObject run() throws AlgoliaException {
-                return multipleQueries(queriesCopy, strategy == null ? null : strategy.toString());
-            }
-        }.start();
+        return multipleQueriesAsync(queries, strategy, /* requestOptions: */ null, completionHandler);
     }
 
     /**
      * Search inside this index synchronously.
      *
+     * @param query Search parameters.
+     * @param requestOptions Request-specific options.
      * @return Search results.
      */
-    protected byte[] searchSyncRaw(@NonNull Query query) throws AlgoliaException {
-        return searchRaw(query);
+    protected byte[] searchSyncRaw(@NonNull Query query, @Nullable RequestOptions requestOptions) throws AlgoliaException {
+        return searchRaw(query, requestOptions);
+    }
+
+    /**
+     * Perform a search with disjunctive facets, generating as many queries as number of disjunctive facets (helper).
+     *
+     * @param query             The query.
+     * @param disjunctiveFacets List of disjunctive facets.
+     * @param refinements       The current refinements, mapping facet names to a list of values.
+     * @param requestOptions Request-specific options.
+     * @param completionHandler The listener that will be notified of the request's outcome.
+     * @return A cancellable request.
+     */
+    public Request searchDisjunctiveFacetingAsync(@NonNull Query query, @NonNull final List<String> disjunctiveFacets, @NonNull final Map<String, List<String>> refinements, @Nullable final RequestOptions requestOptions, @NonNull final CompletionHandler completionHandler) {
+        return new DisjunctiveFaceting() {
+            @Override
+            protected Request multipleQueriesAsync(@NonNull List<Query> queries, @NonNull CompletionHandler completionHandler) {
+                return Index.this.multipleQueriesAsync(queries, null, requestOptions, completionHandler);
+            }
+        }.searchDisjunctiveFacetingAsync(query, disjunctiveFacets, refinements, completionHandler);
     }
 
     /**
@@ -173,12 +235,7 @@ public class Index {
      * @return A cancellable request.
      */
     public Request searchDisjunctiveFacetingAsync(@NonNull Query query, @NonNull final List<String> disjunctiveFacets, @NonNull final Map<String, List<String>> refinements, @NonNull final CompletionHandler completionHandler) {
-        return new DisjunctiveFaceting() {
-            @Override
-            protected Request multipleQueriesAsync(@NonNull List<Query> queries, @NonNull CompletionHandler completionHandler) {
-                return Index.this.multipleQueriesAsync(queries, null, completionHandler);
-            }
-        }.searchDisjunctiveFacetingAsync(query, disjunctiveFacets, refinements, completionHandler);
+        return searchDisjunctiveFacetingAsync(query, disjunctiveFacets, refinements, /* requestOptions: */ null, completionHandler);
     }
 
     /**
@@ -190,11 +247,13 @@ public class Index {
      * @return A cancellable request.
      */
     public Request searchForFacetValuesAsync(@NonNull String facetName, @NonNull String text, @NonNull final CompletionHandler handler) throws AlgoliaException {
-        return searchForFacetValues(facetName, text, null, handler);
+        return searchForFacetValuesAsync(facetName, text, /* requestOptions: */ null, handler);
     }
 
     /**
      * Search (asynchronously) for some text in a facet values.
+     *
+     * @deprecated Please use {@link #searchForFacetValuesAsync(String, String, CompletionHandler)} instead.
      *
      * @param facetName The name of the facet to search. It must have been declared in the index's `attributesForFaceting` setting with the `searchable()` modifier.
      * @param text      The text to search for in the facet's values.
@@ -202,7 +261,7 @@ public class Index {
      * @return A cancellable request.
      */
     public Request searchForFacetValues(@NonNull String facetName, @NonNull String text, @NonNull final CompletionHandler handler) {
-        return searchForFacetValues(facetName, text, null, handler);
+        return searchForFacetValuesAsync(facetName, text, /* requestOptions: */ null, handler);
     }
 
     /**
@@ -215,19 +274,20 @@ public class Index {
      * @return A cancellable request.
      */
     public Request searchForFacetValuesAsync(@NonNull String facetName, @NonNull String facetText, @Nullable Query query, @NonNull final CompletionHandler handler) {
-        return searchForFacetValues(facetName, facetText, query, handler);
+        return searchForFacetValuesAsync(facetName, facetText, query, /* requestOptions: */ null, handler);
     }
 
     /**
-     * Search (asynchronously) for some text in a facet values, optionally restricting the returned values to those contained in objects matching other (regular) search criteria.
+     * Search for some text in a facet values, optionally restricting the returned values to those contained in objects matching other (regular) search criteria.
      *
      * @param facetName The name of the facet to search. It must have been declared in the index's `attributesForFaceting` setting with the `searchable()` modifier.
      * @param facetText The text to search for in the facet's values.
      * @param query     An optional query to take extra search parameters into account. There parameters apply to index objects like in a regular search query. Only facet values contained in the matched objects will be returned
+     * @param requestOptions Request-specific options.
      * @param handler   A Completion handler that will be notified of the request's outcome.
      * @return A cancellable request.
      */
-    public Request searchForFacetValues(@NonNull String facetName, @NonNull String facetText, @Nullable Query query, @NonNull final CompletionHandler handler) {
+    public Request searchForFacetValuesAsync(@NonNull String facetName, @NonNull String facetText, @Nullable Query query, @Nullable final RequestOptions requestOptions, @NonNull final CompletionHandler handler) {
         try {
             final String path = "/1/indexes/" + getEncodedIndexName() + "/facets/" + URLEncoder.encode(facetName, "UTF-8") + "/query";
             final Query params = (query != null ? new Query(query) : new Query());
@@ -239,13 +299,31 @@ public class Index {
                 @NonNull
                 @Override
                 protected JSONObject run() throws AlgoliaException {
-                    return client.postRequest(path, requestBody.toString(), true);
+                    return client.postRequest(path, requestBody.toString(), true, requestOptions);
                 }
             }.start();
         } catch (UnsupportedEncodingException | JSONException e) {
             throw new RuntimeException(e); // should never happen
         }
     }
+
+    /**
+     * Search (asynchronously) for some text in a facet values, optionally restricting the returned values to those contained in objects matching other (regular) search criteria.
+     *
+     * @deprecated Please use {@link #searchForFacetValuesAsync(String, String, Query, CompletionHandler)} instead.
+     *
+     * @param facetName The name of the facet to search. It must have been declared in the index's `attributesForFaceting` setting with the `searchable()` modifier.
+     * @param facetText The text to search for in the facet's values.
+     * @param query     An optional query to take extra search parameters into account. There parameters apply to index objects like in a regular search query. Only facet values contained in the matched objects will be returned
+     * @param handler   A Completion handler that will be notified of the request's outcome.
+     * @return A cancellable request.
+     */
+    public Request searchForFacetValues(@NonNull String facetName, @NonNull String facetText, @Nullable Query query, @NonNull final CompletionHandler handler) {
+        return searchForFacetValuesAsync(facetName, facetText, query, handler);
+    }
+
+    // Manage objects
+    // --------------
 
     /**
      * Add an object to this index (asynchronously).
@@ -262,7 +340,7 @@ public class Index {
         return getClient().new AsyncTaskRequest(completionHandler) {
             @NonNull
             @Override protected JSONObject run() throws AlgoliaException {
-                return addObject(object);
+                return addObject(object, /* requestOptions: */ null);
             }
         }.start();
     }
@@ -281,10 +359,45 @@ public class Index {
      * @return A cancellable request.
      */
     public Request addObjectAsync(final @NonNull JSONObject object, final @NonNull String objectID, CompletionHandler completionHandler) {
+        return addObjectAsync(object, objectID, /* requestOptions: */ null, completionHandler);
+    }
+
+    /**
+     * Add an object to this index, assigning it the specified object ID (asynchronously).
+     * If an object already exists with the same object ID, the existing object will be overwritten.
+     * <p>
+     * WARNING: For performance reasons, the arguments are not cloned. Since the method is executed in the background,
+     * you should not modify the object after it has been passed.
+     * </p>
+     *
+     * @param object            The object to add.
+     * @param objectID          Identifier that you want to assign this object.
+     * @param requestOptions Request-specific options.
+     * @param completionHandler The listener that will be notified of the request's outcome.
+     * @return A cancellable request.
+     */
+    public Request addObjectAsync(final @NonNull JSONObject object, final @NonNull String objectID, @Nullable final RequestOptions requestOptions, CompletionHandler completionHandler) {
         return getClient().new AsyncTaskRequest(completionHandler) {
             @NonNull
             @Override protected JSONObject run() throws AlgoliaException {
-                return addObject(object, objectID);
+                return addObject(object, objectID, requestOptions);
+            }
+        }.start();
+    }
+
+    /**
+     * Add several objects to this index (asynchronously).
+     *
+     * @param objects           Objects to add.
+     * @param requestOptions Request-specific options.
+     * @param completionHandler The listener that will be notified of the request's outcome.
+     * @return A cancellable request.
+     */
+    public Request addObjectsAsync(final @NonNull JSONArray objects, @Nullable final RequestOptions requestOptions, CompletionHandler completionHandler) {
+        return getClient().new AsyncTaskRequest(completionHandler) {
+            @NonNull
+            @Override protected JSONObject run() throws AlgoliaException {
+                return addObjects(objects, requestOptions);
             }
         }.start();
     }
@@ -297,12 +410,7 @@ public class Index {
      * @return A cancellable request.
      */
     public Request addObjectsAsync(final @NonNull JSONArray objects, CompletionHandler completionHandler) {
-        return getClient().new AsyncTaskRequest(completionHandler) {
-            @NonNull
-            @Override protected JSONObject run() throws AlgoliaException {
-                return addObjects(objects);
-            }
-        }.start();
+        return addObjectsAsync(objects, /* requestOptions: */ null, completionHandler);
     }
 
     /**
@@ -314,10 +422,23 @@ public class Index {
      * @return A cancellable request.
      */
     public Request saveObjectAsync(final @NonNull JSONObject object, final @NonNull String objectID, CompletionHandler completionHandler) {
+        return saveObjectAsync(object, objectID, /* requestOptions: */ null, completionHandler);
+    }
+
+    /**
+     * Update an object (asynchronously).
+     *
+     * @param object            New version of the object to update.
+     * @param objectID          Identifier of the object to update.
+     * @param requestOptions Request-specific options.
+     * @param completionHandler The listener that will be notified of the request's outcome.
+     * @return A cancellable request.
+     */
+    public Request saveObjectAsync(final @NonNull JSONObject object, final @NonNull String objectID, @Nullable final RequestOptions requestOptions, CompletionHandler completionHandler) {
         return getClient().new AsyncTaskRequest(completionHandler) {
             @NonNull
             @Override protected JSONObject run() throws AlgoliaException {
-                return saveObject(object, objectID);
+                return saveObject(object, objectID, requestOptions);
             }
         }.start();
     }
@@ -330,10 +451,22 @@ public class Index {
      * @return A cancellable request.
      */
     public Request saveObjectsAsync(final @NonNull JSONArray objects, @NonNull CompletionHandler completionHandler) {
+        return saveObjectsAsync(objects, /* requestOptions: */ null, completionHandler);
+    }
+
+    /**
+     * Update several objects (asynchronously).
+     *
+     * @param objects           Objects to update. Each object must contain an <code>objectID</code> attribute.
+     * @param requestOptions Request-specific options.
+     * @param completionHandler The listener that will be notified of the request's outcome.
+     * @return A cancellable request.
+     */
+    public Request saveObjectsAsync(final @NonNull JSONArray objects, @Nullable final RequestOptions requestOptions, @NonNull CompletionHandler completionHandler) {
         return getClient().new AsyncTaskRequest(completionHandler) {
             @NonNull
             @Override protected JSONObject run() throws AlgoliaException {
-                return saveObjects(objects);
+                return saveObjects(objects, requestOptions);
             }
         }.start();
     }
@@ -351,12 +484,7 @@ public class Index {
      * @return A cancellable request.
      */
     public Request partialUpdateObjectAsync(final @NonNull JSONObject partialObject, final @NonNull String objectID, CompletionHandler completionHandler) {
-        return getClient().new AsyncTaskRequest(completionHandler) {
-            @NonNull
-            @Override protected JSONObject run() throws AlgoliaException {
-                return partialUpdateObject(partialObject, objectID, null);
-            }
-        }.start();
+        return partialUpdateObjectAsync(partialObject, objectID, /* createIfNotExists: */ true, /* requestOptions: */ null, completionHandler);
     }
 
     /**
@@ -369,10 +497,24 @@ public class Index {
      * @return A cancellable request.
      */
     public Request partialUpdateObjectAsync(final @NonNull JSONObject partialObject, final @NonNull String objectID, final boolean createIfNotExists, CompletionHandler completionHandler) {
+        return partialUpdateObjectAsync(partialObject, objectID, createIfNotExists, /* requestOptions: */ null, completionHandler);
+    }
+
+    /**
+     * Partially update an object (asynchronously).
+     *
+     * @param partialObject     New value/operations for the object.
+     * @param objectID          Identifier of object to be updated.
+     * @param createIfNotExists Whether the object should be created if it does not exist already.
+     * @param requestOptions Request-specific options.
+     * @param completionHandler The listener that will be notified of the request's outcome.
+     * @return A cancellable request.
+     */
+    public Request partialUpdateObjectAsync(final @NonNull JSONObject partialObject, final @NonNull String objectID, final boolean createIfNotExists, @Nullable final RequestOptions requestOptions, CompletionHandler completionHandler) {
         return getClient().new AsyncTaskRequest(completionHandler) {
             @NonNull
             @Override protected JSONObject run() throws AlgoliaException {
-                return partialUpdateObject(partialObject, objectID, createIfNotExists);
+                return partialUpdateObject(partialObject, objectID, createIfNotExists, requestOptions);
             }
         }.start();
     }
@@ -390,12 +532,7 @@ public class Index {
      * @return A cancellable request.
      */
     public Request partialUpdateObjectsAsync(final @NonNull JSONArray partialObjects, CompletionHandler completionHandler) {
-        return getClient().new AsyncTaskRequest(completionHandler) {
-            @NonNull
-            @Override protected JSONObject run() throws AlgoliaException {
-                return partialUpdateObjects(partialObjects, true);
-            }
-        }.start();
+        return partialUpdateObjectsAsync(partialObjects, /* createIfNotExists: */ true, /* requestOptions: */ null, completionHandler);
     }
 
     /**
@@ -408,10 +545,24 @@ public class Index {
      * @return A cancellable request.
      */
     public Request partialUpdateObjectsAsync(final @NonNull JSONArray partialObjects, final boolean createIfNotExists, CompletionHandler completionHandler) {
+        return partialUpdateObjectsAsync(partialObjects, createIfNotExists, /* requestOptions: */ null, completionHandler);
+    }
+
+    /**
+     * Partially update several objects (asynchronously).
+     *
+     * @param partialObjects    New values/operations for the objects. Each object must contain an <code>objectID</code>
+     *                          attribute.
+     * @param createIfNotExists Whether objects should be created if they do not exist already.
+     * @param requestOptions Request-specific options.
+     * @param completionHandler The listener that will be notified of the request's outcome.
+     * @return A cancellable request.
+     */
+    public Request partialUpdateObjectsAsync(final @NonNull JSONArray partialObjects, final boolean createIfNotExists, @Nullable final RequestOptions requestOptions, CompletionHandler completionHandler) {
         return getClient().new AsyncTaskRequest(completionHandler) {
             @NonNull
             @Override protected JSONObject run() throws AlgoliaException {
-                return partialUpdateObjects(partialObjects, createIfNotExists);
+                return partialUpdateObjects(partialObjects, createIfNotExists, requestOptions);
             }
         }.start();
     }
@@ -424,7 +575,7 @@ public class Index {
      * @return A cancellable request.
      */
     public Request getObjectAsync(final @NonNull String objectID, @NonNull CompletionHandler completionHandler) {
-        return getObjectAsync(objectID, null, completionHandler);
+        return getObjectAsync(objectID, /* attributesToRetrieve: */ null, /* requestOptions: */ null, completionHandler);
     }
 
     /**
@@ -436,10 +587,23 @@ public class Index {
      * @return A cancellable request.
      */
     public Request getObjectAsync(final @NonNull String objectID, final List<String> attributesToRetrieve, @NonNull CompletionHandler completionHandler) {
+        return getObjectAsync(objectID, attributesToRetrieve, /* requestOptions: */ null, completionHandler);
+    }
+
+    /**
+     * Get an object from this index, optionally restricting the retrieved content (asynchronously).
+     *
+     * @param objectID             Identifier of the object to retrieve.
+     * @param attributesToRetrieve List of attributes to retrieve.
+     * @param requestOptions Request-specific options.
+     * @param completionHandler    The listener that will be notified of the request's outcome.
+     * @return A cancellable request.
+     */
+    public Request getObjectAsync(final @NonNull String objectID, final List<String> attributesToRetrieve, @Nullable final RequestOptions requestOptions, @NonNull CompletionHandler completionHandler) {
         return getClient().new AsyncTaskRequest(completionHandler) {
             @NonNull
             @Override protected JSONObject run() throws AlgoliaException {
-                return getObject(objectID, attributesToRetrieve);
+                return getObject(objectID, attributesToRetrieve, requestOptions);
             }
         }.start();
     }
@@ -452,7 +616,7 @@ public class Index {
      * @return A cancellable request.
      */
     public Request getObjectsAsync(final @NonNull List<String> objectIDs, @NonNull CompletionHandler completionHandler) {
-        return getObjectsAsync(objectIDs, null, completionHandler);
+        return getObjectsAsync(objectIDs, /* attributesToRetrieve: */ null, /* requestOptions: */ null, completionHandler);
     }
 
     /**
@@ -464,10 +628,23 @@ public class Index {
      * @return A cancellable request.
      */
     public Request getObjectsAsync(final @NonNull List<String> objectIDs, final List<String> attributesToRetrieve, @NonNull CompletionHandler completionHandler) {
+        return getObjectsAsync(objectIDs, attributesToRetrieve, /* requestOptions: */ null, completionHandler);
+    }
+
+    /**
+     * Get several objects from this index (asynchronously), optionally restricting the retrieved content (asynchronously).
+     *
+     * @param objectIDs            Identifiers of objects to retrieve.
+     * @param attributesToRetrieve List of attributes to retrieve.
+     * @param requestOptions Request-specific options.
+     * @param completionHandler    The listener that will be notified of the request's outcome.
+     * @return A cancellable request.
+     */
+    public Request getObjectsAsync(final @NonNull List<String> objectIDs, final List<String> attributesToRetrieve, @Nullable final RequestOptions requestOptions, @NonNull CompletionHandler completionHandler) {
         return getClient().new AsyncTaskRequest(completionHandler) {
             @NonNull
             @Override protected JSONObject run() throws AlgoliaException {
-                return getObjects(objectIDs, attributesToRetrieve);
+                return getObjects(objectIDs, attributesToRetrieve, requestOptions);
             }
         }.start();
     }
@@ -516,10 +693,22 @@ public class Index {
      * @return A cancellable request.
      */
     public Request deleteObjectAsync(final @NonNull String objectID, CompletionHandler completionHandler) {
+        return deleteObjectAsync(objectID, /* requestOptions: */ null, completionHandler);
+    }
+
+    /**
+     * Delete an object from this index (asynchronously).
+     *
+     * @param objectID          Identifier of the object to delete.
+     * @param requestOptions Request-specific options.
+     * @param completionHandler The listener that will be notified of the request's outcome.
+     * @return A cancellable request.
+     */
+    public Request deleteObjectAsync(final @NonNull String objectID, @Nullable final RequestOptions requestOptions, CompletionHandler completionHandler) {
         return getClient().new AsyncTaskRequest(completionHandler) {
             @NonNull
             @Override protected JSONObject run() throws AlgoliaException {
-                return deleteObject(objectID);
+                return deleteObject(objectID, requestOptions);
             }
         }.start();
     }
@@ -532,10 +721,22 @@ public class Index {
      * @return A cancellable request.
      */
     public Request deleteObjectsAsync(final @NonNull List<String> objectIDs, CompletionHandler completionHandler) {
+        return deleteObjectsAsync(objectIDs, /* requestOptions: */ null, completionHandler);
+    }
+
+    /**
+     * Delete several objects from this index (asynchronously).
+     *
+     * @param objectIDs         Identifiers of objects to delete.
+     * @param requestOptions Request-specific options.
+     * @param completionHandler The listener that will be notified of the request's outcome.
+     * @return A cancellable request.
+     */
+    public Request deleteObjectsAsync(final @NonNull List<String> objectIDs, @Nullable final RequestOptions requestOptions, CompletionHandler completionHandler) {
         return getClient().new AsyncTaskRequest(completionHandler) {
             @NonNull
             @Override protected JSONObject run() throws AlgoliaException {
-                return deleteObjects(objectIDs);
+                return deleteObjects(objectIDs, requestOptions);
             }
         }.start();
     }
@@ -548,11 +749,23 @@ public class Index {
      * @return A cancellable request.
      */
     public Request deleteByQueryAsync(@NonNull Query query, CompletionHandler completionHandler) {
+        return deleteByQueryAsync(query, /* requestOptions: */ null, completionHandler);
+    }
+
+    /**
+     * Delete all objects matching a query (helper).
+     *
+     * @param query             The query that objects to delete must match.
+     * @param requestOptions Request-specific options.
+     * @param completionHandler The listener that will be notified of the request's outcome.
+     * @return A cancellable request.
+     */
+    public Request deleteByQueryAsync(@NonNull Query query, @Nullable final RequestOptions requestOptions, CompletionHandler completionHandler) {
         final Query queryCopy = new Query(query);
         return getClient().new AsyncTaskRequest(completionHandler) {
             @NonNull
             @Override protected JSONObject run() throws AlgoliaException {
-                deleteByQuery(queryCopy);
+                deleteByQuery(queryCopy, requestOptions);
                 return new JSONObject();
             }
         }.start();
@@ -565,10 +778,21 @@ public class Index {
      * @return A cancellable request.
      */
     public Request getSettingsAsync(@NonNull CompletionHandler completionHandler) {
+        return getSettingsAsync(/* requestOptions */ null, completionHandler);
+    }
+
+    /**
+     * Get this index's settings (asynchronously).
+     *
+     * @param requestOptions Request-specific options.
+     * @param completionHandler The listener that will be notified of the request's outcome.
+     * @return A cancellable request.
+     */
+    public Request getSettingsAsync(@Nullable final RequestOptions requestOptions, @NonNull CompletionHandler completionHandler) {
         return getClient().new AsyncTaskRequest(completionHandler) {
             @NonNull
             @Override protected JSONObject run() throws AlgoliaException {
-                return getSettings(2);
+                return getSettings(2, requestOptions);
             }
         }.start();
     }
@@ -584,10 +808,25 @@ public class Index {
      * @return A cancellable request.
      */
     public Request setSettingsAsync(final @NonNull JSONObject settings, CompletionHandler completionHandler) {
+        return setSettingsAsync(settings, /* forwardToReplicas: */ false, /* requestOptions: */ null, completionHandler);
+    }
+
+    /**
+     * Set this index's settings (asynchronously).
+     * <p>
+     * Please refer to our <a href="https://www.algolia.com/doc/android#index-settings">API documentation</a> for the
+     * list of supported settings.
+     *
+     * @param settings          New settings.
+     * @param requestOptions Request-specific options.
+     * @param completionHandler The listener that will be notified of the request's outcome.
+     * @return A cancellable request.
+     */
+    public Request setSettingsAsync(final @NonNull JSONObject settings, final boolean forwardToReplicas, @Nullable final RequestOptions requestOptions, CompletionHandler completionHandler) {
         return getClient().new AsyncTaskRequest(completionHandler) {
             @NonNull
             @Override protected JSONObject run() throws AlgoliaException {
-                return setSettings(settings);
+                return setSettings(settings, forwardToReplicas, requestOptions);
             }
         }.start();
     }
@@ -603,11 +842,26 @@ public class Index {
      * @return A cancellable request.
      */
     public Request browseAsync(@NonNull Query query, @NonNull CompletionHandler completionHandler) {
+        return browseAsync(query, /* requestOptions: */ null, completionHandler);
+    }
+
+    /**
+     * Browse all index content (initial call).
+     * This method should be called once to initiate a browse. It will return the first page of results and a cursor,
+     * unless the end of the index has been reached. To retrieve subsequent pages, call `browseFromAsync` with that
+     * cursor.
+     *
+     * @param query             The query parameters for the browse.
+     * @param requestOptions Request-specific options.
+     * @param completionHandler The listener that will be notified of the request's outcome.
+     * @return A cancellable request.
+     */
+    public Request browseAsync(@NonNull Query query, @Nullable final RequestOptions requestOptions, @NonNull CompletionHandler completionHandler) {
         final Query queryCopy = new Query(query);
         return getClient().new AsyncTaskRequest(completionHandler) {
             @NonNull
             @Override protected JSONObject run() throws AlgoliaException {
-                return browse(queryCopy);
+                return browse(queryCopy, requestOptions);
             }
         }.start();
     }
@@ -622,10 +876,24 @@ public class Index {
      * @return A cancellable request.
      */
     public Request browseFromAsync(final @NonNull String cursor, @NonNull CompletionHandler completionHandler) {
+        return browseFromAsync(cursor, /* requestOptions: */ null, completionHandler);
+    }
+
+    /**
+     * Browse the index from a cursor.
+     * This method should be called after an initial call to `browseAsync()`. It returns a cursor, unless the end of
+     * the index has been reached.
+     *
+     * @param cursor            The cursor of the next page to retrieve.
+     * @param requestOptions Request-specific options.
+     * @param completionHandler The listener that will be notified of the request's outcome.
+     * @return A cancellable request.
+     */
+    public Request browseFromAsync(final @NonNull String cursor, @Nullable final RequestOptions requestOptions, @NonNull CompletionHandler completionHandler) {
         return getClient().new AsyncTaskRequest(completionHandler) {
             @NonNull
             @Override protected JSONObject run() throws AlgoliaException {
-                return browseFrom(cursor);
+                return browseFrom(cursor, requestOptions);
             }
         }.start();
     }
@@ -637,10 +905,21 @@ public class Index {
      * @return A cancellable request.
      */
     public Request clearIndexAsync(CompletionHandler completionHandler) {
+        return clearIndexAsync(/* requestOptions: */ null, completionHandler);
+    }
+
+    /**
+     * Clear this index.
+     *
+     * @param requestOptions Request-specific options.
+     * @param completionHandler The listener that will be notified of the request's outcome.
+     * @return A cancellable request.
+     */
+    public Request clearIndexAsync(@Nullable final RequestOptions requestOptions, CompletionHandler completionHandler) {
         return getClient().new AsyncTaskRequest(completionHandler) {
             @NonNull
             @Override protected JSONObject run() throws AlgoliaException {
-                return clearIndex();
+                return clearIndex(requestOptions);
             }
         }.start();
     }
@@ -694,10 +973,11 @@ public class Index {
      * Add an object in this index
      *
      * @param obj the object to add.
+     * @param requestOptions Request-specific options.
      * @throws AlgoliaException
      */
-    protected JSONObject addObject(JSONObject obj) throws AlgoliaException {
-        return client.postRequest("/1/indexes/" + encodedIndexName, obj.toString(), false);
+    protected JSONObject addObject(JSONObject obj, @Nullable RequestOptions requestOptions) throws AlgoliaException {
+        return client.postRequest("/1/indexes/" + encodedIndexName, obj.toString(), false, requestOptions);
     }
 
     /**
@@ -706,11 +986,12 @@ public class Index {
      * @param obj      the object to add.
      * @param objectID an objectID you want to attribute to this object
      *                 (if the attribute already exist the old object will be overwrite)
+     * @param requestOptions Request-specific options.
      * @throws AlgoliaException
      */
-    protected JSONObject addObject(JSONObject obj, String objectID) throws AlgoliaException {
+    protected JSONObject addObject(JSONObject obj, String objectID, @Nullable RequestOptions requestOptions) throws AlgoliaException {
         try {
-            return client.putRequest("/1/indexes/" + encodedIndexName + "/" + URLEncoder.encode(objectID, "UTF-8"), obj.toString());
+            return client.putRequest("/1/indexes/" + encodedIndexName + "/" + URLEncoder.encode(objectID, "UTF-8"), obj.toString(), requestOptions);
         } catch (UnsupportedEncodingException e) {
             throw new AlgoliaException(e.getMessage());
         }
@@ -720,13 +1001,14 @@ public class Index {
      * Custom batch
      *
      * @param actions the array of actions
+     * @param requestOptions Request-specific options.
      * @throws AlgoliaException
      */
-    protected JSONObject batch(JSONArray actions) throws AlgoliaException {
+    protected JSONObject batch(JSONArray actions, @Nullable RequestOptions requestOptions) throws AlgoliaException {
         try {
             JSONObject content = new JSONObject();
             content.put("requests", actions);
-            return client.postRequest("/1/indexes/" + encodedIndexName + "/batch", content.toString(), false);
+            return client.postRequest("/1/indexes/" + encodedIndexName + "/batch", content.toString(), false, requestOptions);
         } catch (JSONException e) {
             throw new AlgoliaException(e.getMessage());
         }
@@ -736,9 +1018,10 @@ public class Index {
      * Add several objects
      *
      * @param inputArray contains an array of objects to add.
+     * @param requestOptions Request-specific options.
      * @throws AlgoliaException
      */
-    protected JSONObject addObjects(JSONArray inputArray) throws AlgoliaException {
+    protected JSONObject addObjects(JSONArray inputArray, @Nullable RequestOptions requestOptions) throws AlgoliaException {
         try {
             JSONArray array = new JSONArray();
             for (int n = 0; n < inputArray.length(); n++) {
@@ -747,7 +1030,7 @@ public class Index {
                 action.put("body", inputArray.getJSONObject(n));
                 array.put(action);
             }
-            return batch(array);
+            return batch(array, requestOptions);
         } catch (JSONException e) {
             throw new AlgoliaException(e.getMessage());
         }
@@ -757,11 +1040,12 @@ public class Index {
      * Get an object from this index
      *
      * @param objectID the unique identifier of the object to retrieve
+     * @param requestOptions Request-specific options.
      * @throws AlgoliaException
      */
-    protected JSONObject getObject(String objectID) throws AlgoliaException {
+    protected JSONObject getObject(String objectID, @Nullable RequestOptions requestOptions) throws AlgoliaException {
         try {
-            return client.getRequest("/1/indexes/" + encodedIndexName + "/" + URLEncoder.encode(objectID, "UTF-8"), false);
+            return client.getRequest("/1/indexes/" + encodedIndexName + "/" + URLEncoder.encode(objectID, "UTF-8"), false, requestOptions);
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }
@@ -772,15 +1056,16 @@ public class Index {
      *
      * @param objectID             the unique identifier of the object to retrieve
      * @param attributesToRetrieve contains the list of attributes to retrieve.
+     * @param requestOptions Request-specific options.
      * @throws AlgoliaException
      */
-    protected JSONObject getObject(String objectID, List<String> attributesToRetrieve) throws AlgoliaException {
+    protected JSONObject getObject(String objectID, List<String> attributesToRetrieve, @Nullable RequestOptions requestOptions) throws AlgoliaException {
         try {
             String path = "/1/indexes/" + encodedIndexName + "/" + URLEncoder.encode(objectID, "UTF-8");
             if (attributesToRetrieve != null) {
                 path += encodeAttributes(attributesToRetrieve, true); // includes the query separator (`?`)
             }
-            return client.getRequest(path, false);
+            return client.getRequest(path, false, requestOptions);
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }
@@ -793,7 +1078,7 @@ public class Index {
      * @throws AlgoliaException
      */
     protected JSONObject getObjects(List<String> objectIDs) throws AlgoliaException {
-        return getObjects(objectIDs, null);
+        return getObjects(objectIDs, /* attributesToRetrieve: */ null, /* requestOptions: */ null);
     }
 
     /**
@@ -801,9 +1086,10 @@ public class Index {
      *
      * @param objectIDs            the array of unique identifier of objects to retrieve
      * @param attributesToRetrieve contains the list of attributes to retrieve.
+     * @param requestOptions Request-specific options.
      * @throws AlgoliaException
      */
-    protected JSONObject getObjects(List<String> objectIDs, List<String> attributesToRetrieve) throws AlgoliaException {
+    protected JSONObject getObjects(List<String> objectIDs, List<String> attributesToRetrieve, @Nullable RequestOptions requestOptions) throws AlgoliaException {
         try {
             JSONArray requests = new JSONArray();
             for (String id : objectIDs) {
@@ -815,7 +1101,7 @@ public class Index {
             }
             JSONObject body = new JSONObject();
             body.put("requests", requests);
-            return client.postRequest("/1/indexes/*/objects", body.toString(), true);
+            return client.postRequest("/1/indexes/*/objects", body.toString(), true, requestOptions);
         } catch (JSONException | UnsupportedEncodingException e) {
             throw new AlgoliaException(e.getMessage());
         }
@@ -844,15 +1130,16 @@ public class Index {
      * Update partially an object (only update attributes passed in argument)
      *
      * @param partialObject the object attributes to override
+     * @param requestOptions Request-specific options.
      * @throws AlgoliaException
      */
-    protected JSONObject partialUpdateObject(JSONObject partialObject, String objectID, Boolean createIfNotExists) throws AlgoliaException {
+    protected JSONObject partialUpdateObject(JSONObject partialObject, String objectID, Boolean createIfNotExists, @Nullable RequestOptions requestOptions) throws AlgoliaException {
         try {
             String path = "/1/indexes/" + encodedIndexName + "/" + URLEncoder.encode(objectID, "UTF-8") + "/partial";
             if (createIfNotExists != null) {
                 path += "?createIfNotExists=" + createIfNotExists.toString();
             }
-            return client.postRequest(path, partialObject.toString(), false);
+            return client.postRequest(path, partialObject.toString(), false, requestOptions);
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }
@@ -862,9 +1149,10 @@ public class Index {
      * Partially Override the content of several objects
      *
      * @param inputArray the array of objects to update (each object must contains an objectID attribute)
+     * @param requestOptions Request-specific options.
      * @throws AlgoliaException
      */
-    protected JSONObject partialUpdateObjects(JSONArray inputArray, boolean createIfNotExists) throws AlgoliaException {
+    protected JSONObject partialUpdateObjects(JSONArray inputArray, boolean createIfNotExists, @Nullable RequestOptions requestOptions) throws AlgoliaException {
         try {
             final String action = createIfNotExists ? "partialUpdateObject" : "partialUpdateObjectNoCreate";
             JSONArray array = new JSONArray();
@@ -876,7 +1164,7 @@ public class Index {
                 operation.put("body", obj);
                 array.put(operation);
             }
-            return batch(array);
+            return batch(array, requestOptions);
         } catch (JSONException e) {
             throw new AlgoliaException(e.getMessage());
         }
@@ -886,11 +1174,12 @@ public class Index {
      * Override the content of object
      *
      * @param object the object to save
+     * @param requestOptions Request-specific options.
      * @throws AlgoliaException
      */
-    protected JSONObject saveObject(JSONObject object, String objectID) throws AlgoliaException {
+    protected JSONObject saveObject(JSONObject object, String objectID, @Nullable RequestOptions requestOptions) throws AlgoliaException {
         try {
-            return client.putRequest("/1/indexes/" + encodedIndexName + "/" + URLEncoder.encode(objectID, "UTF-8"), object.toString());
+            return client.putRequest("/1/indexes/" + encodedIndexName + "/" + URLEncoder.encode(objectID, "UTF-8"), object.toString(), requestOptions);
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }
@@ -900,9 +1189,10 @@ public class Index {
      * Override the content of several objects
      *
      * @param inputArray contains an array of objects to update (each object must contains an objectID attribute)
+     * @param requestOptions Request-specific options.
      * @throws AlgoliaException
      */
-    protected JSONObject saveObjects(JSONArray inputArray) throws AlgoliaException {
+    protected JSONObject saveObjects(JSONArray inputArray, @Nullable RequestOptions requestOptions) throws AlgoliaException {
         try {
             JSONArray array = new JSONArray();
             for (int n = 0; n < inputArray.length(); n++) {
@@ -913,7 +1203,7 @@ public class Index {
                 action.put("body", obj);
                 array.put(action);
             }
-            return batch(array);
+            return batch(array, requestOptions);
         } catch (JSONException e) {
             throw new AlgoliaException(e.getMessage());
         }
@@ -923,14 +1213,15 @@ public class Index {
      * Delete an object from the index
      *
      * @param objectID the unique identifier of object to delete
+     * @param requestOptions Request-specific options.
      * @throws AlgoliaException
      */
-    protected JSONObject deleteObject(String objectID) throws AlgoliaException {
+    protected JSONObject deleteObject(String objectID, @Nullable RequestOptions requestOptions) throws AlgoliaException {
         if (objectID.length() == 0) {
             throw new AlgoliaException("Invalid objectID");
         }
         try {
-            return client.deleteRequest("/1/indexes/" + encodedIndexName + "/" + URLEncoder.encode(objectID, "UTF-8"));
+            return client.deleteRequest("/1/indexes/" + encodedIndexName + "/" + URLEncoder.encode(objectID, "UTF-8"), requestOptions);
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }
@@ -940,9 +1231,10 @@ public class Index {
      * Delete several objects
      *
      * @param objects the array of objectIDs to delete
+     * @param requestOptions Request-specific options.
      * @throws AlgoliaException
      */
-    protected JSONObject deleteObjects(List<String> objects) throws AlgoliaException {
+    protected JSONObject deleteObjects(List<String> objects, @Nullable RequestOptions requestOptions) throws AlgoliaException {
         try {
             JSONArray array = new JSONArray();
             for (String id : objects) {
@@ -953,7 +1245,7 @@ public class Index {
                 action.put("body", obj);
                 array.put(action);
             }
-            return batch(array);
+            return batch(array, requestOptions);
         } catch (JSONException e) {
             throw new AlgoliaException(e.getMessage());
         }
@@ -963,16 +1255,17 @@ public class Index {
      * Delete all objects matching a query
      *
      * @param query the query string
+     * @param requestOptions Request-specific options.
      * @throws AlgoliaException
      */
-    protected void deleteByQuery(@NonNull Query query) throws AlgoliaException {
+    protected void deleteByQuery(@NonNull Query query, @Nullable RequestOptions requestOptions) throws AlgoliaException {
         try {
             boolean hasMore;
             do {
                 // Browse index for the next batch of objects.
                 // WARNING: Since deletion invalidates cursors, we always browse from the start.
                 List<String> objectIDs = new ArrayList<>(1000);
-                JSONObject content = browse(query);
+                JSONObject content = browse(query, requestOptions);
                 JSONArray hits = content.getJSONArray("hits");
                 for (int i = 0; i < hits.length(); ++i) {
                     JSONObject hit = hits.getJSONObject(i);
@@ -981,7 +1274,7 @@ public class Index {
                 hasMore = content.optString("cursor", null) != null;
 
                 // Delete objects.
-                JSONObject task = this.deleteObjects(objectIDs);
+                JSONObject task = this.deleteObjects(objectIDs, /* requestOptions: */ null);
                 this.waitTask(task.getString("taskID"));
             }
             while (hasMore);
@@ -994,9 +1287,10 @@ public class Index {
      * Search inside the index
      *
      * @return a JSONObject containing search results
+     * @param requestOptions Request-specific options.
      * @throws AlgoliaException
      */
-    protected JSONObject search(@Nullable Query query) throws AlgoliaException {
+    protected JSONObject search(@Nullable Query query, @Nullable RequestOptions requestOptions) throws AlgoliaException {
         if (query == null) {
             query = new Query();
         }
@@ -1009,7 +1303,7 @@ public class Index {
         }
         try {
             if (rawResponse == null) {
-                rawResponse = searchRaw(query);
+                rawResponse = searchRaw(query, requestOptions);
                 if (isCacheEnabled) {
                     searchCache.put(cacheKey, rawResponse);
                 }
@@ -1024,9 +1318,10 @@ public class Index {
      * Search inside the index
      *
      * @return a byte array containing search results
+     * @param requestOptions Request-specific options.
      * @throws AlgoliaException
      */
-    protected byte[] searchRaw(@Nullable Query query) throws AlgoliaException {
+    protected byte[] searchRaw(@Nullable Query query, @Nullable RequestOptions requestOptions) throws AlgoliaException {
         if (query == null) {
             query = new Query();
         }
@@ -1036,9 +1331,9 @@ public class Index {
             if (paramsString.length() > 0) {
                 JSONObject body = new JSONObject();
                 body.put("params", paramsString);
-                return client.postRequestRaw("/1/indexes/" + encodedIndexName + "/query", body.toString(), true);
+                return client.postRequestRaw("/1/indexes/" + encodedIndexName + "/query", body.toString(), true, requestOptions);
             } else {
-                return client.getRequestRaw("/1/indexes/" + encodedIndexName, true);
+                return client.getRequestRaw("/1/indexes/" + encodedIndexName, true, requestOptions);
             }
         } catch (JSONException e) {
             throw new RuntimeException(e); // should never happen
@@ -1056,7 +1351,7 @@ public class Index {
     protected JSONObject waitTask(String taskID, long timeToWait) throws AlgoliaException {
         try {
             while (true) {
-                JSONObject obj = client.getRequest("/1/indexes/" + encodedIndexName + "/task/" + URLEncoder.encode(taskID, "UTF-8"), false);
+                JSONObject obj = client.getRequest("/1/indexes/" + encodedIndexName + "/task/" + URLEncoder.encode(taskID, "UTF-8"), false, /* requestOptions: */ null);
                 if (obj.getString("status").equals("published")) {
                     return obj;
                 }
@@ -1089,9 +1384,11 @@ public class Index {
 
     /**
      * Gets the settings of this index.
+     *
+     * @param requestOptions Request-specific options.
      */
-    protected JSONObject getSettings() throws AlgoliaException {
-        return client.getRequest("/1/indexes/" + encodedIndexName + "/settings?getVersion=" + DEFAULT_SETTINGS_VERSION, false);
+    protected JSONObject getSettings(@Nullable RequestOptions requestOptions) throws AlgoliaException {
+        return client.getRequest("/1/indexes/" + encodedIndexName + "/settings?getVersion=" + DEFAULT_SETTINGS_VERSION, false, requestOptions);
     }
 
 
@@ -1099,20 +1396,11 @@ public class Index {
      * Gets the settings of this index for a specific settings format.
      *
      * @param formatVersion the version of a settings format.
+     * @param requestOptions Request-specific options.
      * @throws AlgoliaException
      */
-    protected JSONObject getSettings(int formatVersion) throws AlgoliaException {
-        return client.getRequest("/1/indexes/" + encodedIndexName + "/settings?getVersion=" + formatVersion, false);
-    }
-
-    /**
-     * Set settings for this index, not forwarding to replica indices.
-     *
-     * @param settings the settings object.
-     * @throws AlgoliaException
-     */
-    protected JSONObject setSettings(JSONObject settings) throws AlgoliaException {
-        return setSettings(settings, false);
+    protected JSONObject getSettings(int formatVersion, @Nullable RequestOptions requestOptions) throws AlgoliaException {
+        return client.getRequest("/1/indexes/" + encodedIndexName + "/settings?getVersion=" + formatVersion, false, requestOptions);
     }
 
     /**
@@ -1120,29 +1408,31 @@ public class Index {
      *
      * @param settings          the settings object.
      * @param forwardToReplicas if true, the new settings will be forwarded to replica indices.
+     * @param requestOptions Request-specific options.
      * @throws AlgoliaException
      */
-    protected JSONObject setSettings(JSONObject settings, boolean forwardToReplicas) throws AlgoliaException {
+    protected JSONObject setSettings(JSONObject settings, boolean forwardToReplicas, @Nullable RequestOptions requestOptions) throws AlgoliaException {
         final String url = "/1/indexes/" + encodedIndexName + "/settings" + "?forwardToReplicas=" + forwardToReplicas;
-        return client.putRequest(url, settings.toString());
+        return client.putRequest(url, settings.toString(), requestOptions);
     }
 
     /**
      * Delete the index content without removing settings and index specific API keys.
      *
+     * @param requestOptions Request-specific options.
      * @throws AlgoliaException
      */
-    protected JSONObject clearIndex() throws AlgoliaException {
-        return client.postRequest("/1/indexes/" + encodedIndexName + "/clear", "", false);
+    protected JSONObject clearIndex(@Nullable RequestOptions requestOptions) throws AlgoliaException {
+        return client.postRequest("/1/indexes/" + encodedIndexName + "/clear", "", false, requestOptions);
     }
 
-    protected JSONObject browse(@NonNull Query query) throws AlgoliaException {
-        return client.getRequest("/1/indexes/" + encodedIndexName + "/browse?" + query.build(), true);
+    protected JSONObject browse(@NonNull Query query, @Nullable RequestOptions requestOptions) throws AlgoliaException {
+        return client.getRequest("/1/indexes/" + encodedIndexName + "/browse?" + query.build(), true, requestOptions);
     }
 
-    protected JSONObject browseFrom(@NonNull String cursor) throws AlgoliaException {
+    protected JSONObject browseFrom(@NonNull String cursor, @Nullable RequestOptions requestOptions) throws AlgoliaException {
         try {
-            return client.getRequest("/1/indexes/" + encodedIndexName + "/browse?cursor=" + URLEncoder.encode(cursor, "UTF-8"), true);
+            return client.getRequest("/1/indexes/" + encodedIndexName + "/browse?cursor=" + URLEncoder.encode(cursor, "UTF-8"), true, requestOptions);
         } catch (UnsupportedEncodingException e) {
             throw new Error(e); // Should never happen: UTF-8 is always supported.
         }
@@ -1150,18 +1440,19 @@ public class Index {
 
     /**
      * Run multiple queries on this index with one API call.
-     * A variant of {@link Client#multipleQueries(List, String)} where all queries target this index.
+     * A variant of {@link Client#multipleQueries(List, String, RequestOptions)} where all queries target this index.
      *
      * @param queries  Queries to run.
      * @param strategy Strategy to use.
+     * @param requestOptions Request-specific options.
      * @return The JSON results returned by the server.
      * @throws AlgoliaException
      */
-    protected JSONObject multipleQueries(@NonNull List<Query> queries, String strategy) throws AlgoliaException {
+    protected JSONObject multipleQueries(@NonNull List<Query> queries, String strategy, @Nullable RequestOptions requestOptions) throws AlgoliaException {
         List<IndexQuery> requests = new ArrayList<>(queries.size());
         for (Query query : queries) {
             requests.add(new IndexQuery(this, query));
         }
-        return client.multipleQueries(requests, strategy);
+        return client.multipleQueries(requests, strategy, requestOptions);
     }
 }

--- a/algoliasearch/src/main/java/com/algolia/search/saas/RequestOptions.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/RequestOptions.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2012-2017 Algolia
+ * http://www.algolia.com/
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.algolia.search.saas;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Per-request options.
+ * This class allows specifying options at the request level, overriding default options at the {@link Client} level.
+ *
+ * NOTE: These are reserved for advanced use cases. In most situations, they shouldn't be needed.
+ */
+public class RequestOptions {
+    // Low-level storage
+    // -----------------
+
+    /** HTTP headers, as untyped values. */
+    @NonNull
+    Map<String, String> headers = new HashMap<>();
+
+    /**
+     * Set a HTTP header (untyped version).
+     * Whenever possible, you should use a typed accessor.
+     *
+     * @param name Name of the header.
+     * @param value Value of the header, or `null` to remove the header.
+     */
+    public RequestOptions setHeader(@NonNull String name, @Nullable String value) {
+        if (value == null) {
+            headers.remove(name);
+        } else {
+            headers.put(name, value);
+        }
+        return this;
+    }
+
+    /**
+     * Get the value of a HTTP header.
+     *
+     * @param name Name of the header.
+     * @return Value of the header, or `null` if it does not exist.
+     */
+    public String getHeader(@NonNull String name) {
+        return headers.get(name);
+    }
+
+    // Debug
+    // -----
+
+    @Override
+    public @NonNull String toString() {
+        return String.format("%s{headers: %s}", this.getClass().getSimpleName(), this.headers);
+    }
+
+    // Comparison
+    // ----------
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof RequestOptions)) return false;
+        RequestOptions another = (RequestOptions)obj;
+        return this.headers.equals(another.headers);
+    }
+
+    // Construction
+    // ------------
+
+    /**
+     * Construct empty request options.
+     */
+    public RequestOptions() {
+    }
+}

--- a/algoliasearch/src/main/java/com/algolia/search/saas/places/PlacesClient.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/places/PlacesClient.java
@@ -121,7 +121,7 @@ public class PlacesClient extends AbstractClient {
         try {
             JSONObject body = new JSONObject()
                 .put("params", params.build());
-            return postRequest("/1/places/query", body.toString(), true /* readOperation */);
+            return postRequest("/1/places/query", body.toString(), true /* readOperation */, /* requestOptions: */ null);
         }
         catch (JSONException e) {
             throw new RuntimeException(e); // should never happen

--- a/algoliasearch/src/test/java/com/algolia/search/saas/BrowseIteratorTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/BrowseIteratorTest.java
@@ -60,7 +60,7 @@ public class BrowseIteratorTest extends RobolectricTestCase {
         for (int i = 0; i < 1500; ++i) {
             objects.add(new JSONObject(String.format("{\"dummy\": %d}", i)));
         }
-        JSONObject task = index.addObjects(new JSONArray(objects));
+        JSONObject task = index.addObjects(new JSONArray(objects), /* requestOptions: */ null);
         index.waitTask(task.getString("taskID"));
 
         JSONArray objectIDs = task.getJSONArray("objectIDs");
@@ -72,7 +72,7 @@ public class BrowseIteratorTest extends RobolectricTestCase {
 
     @Override
     public void tearDown() throws Exception {
-        client.deleteIndex(indexName);
+        client.deleteIndex(indexName, /* requestOptions: */ null);
     }
 
     @Test

--- a/algoliasearch/src/test/java/com/algolia/search/saas/IndexTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/IndexTest.java
@@ -54,6 +54,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -95,13 +96,13 @@ public class IndexTest extends RobolectricTestCase {
 
         if (!didInitIndices) {
             Index originalIndex = client.getIndex(originalIndexName);
-            client.deleteIndex(originalIndexName);
+            client.deleteIndex(originalIndexName, /* requestOptions: */ null);
 
             originalObjects = new ArrayList<>();
             originalObjects.add(new JSONObject("{\"city\": \"San Francisco\", \"state\": \"CA\"}"));
             originalObjects.add(new JSONObject("{\"city\": \"San José\", \"state\": \"CA\"}"));
 
-            JSONObject task = originalIndex.addObjects(new JSONArray(originalObjects));
+            JSONObject task = originalIndex.addObjects(new JSONArray(originalObjects), /* requestOptions: */ null);
             originalIndex.waitTask(task.getString("taskID"));
 
             JSONArray objectIDs = task.getJSONArray("objectIDs");
@@ -114,8 +115,8 @@ public class IndexTest extends RobolectricTestCase {
 
             for (int i = 0; i < COUNT_TEST_INDICES; i++) {
                 final String iterIndexName = originalIndexName + i;
-                client.deleteIndex(iterIndexName);
-                task = client.copyIndex(originalIndexName, iterIndexName);
+                client.deleteIndex(iterIndexName, /* requestOptions: */ null);
+                task = client.copyIndex(originalIndexName, iterIndexName, /* requestOptions: */ null);
             }
             originalIndex.waitTask(task.getString("taskID"));
         }
@@ -130,7 +131,7 @@ public class IndexTest extends RobolectricTestCase {
     @Override
     public void tearDown() {
         try {
-            client.deleteIndex(indexName);
+            client.deleteIndex(indexName, /* requestOptions: */ null);
         }
         catch (AlgoliaException e) {
             fail(e.getMessage());
@@ -181,7 +182,7 @@ public class IndexTest extends RobolectricTestCase {
     @Test
     public void searchDisjunctiveFacetingAsync() throws Exception {
         // Set index settings.
-        JSONObject setSettingsResult = index.setSettings(new JSONObject("{\"attributesForFaceting\": [\"brand\", \"category\"]}"));
+        JSONObject setSettingsResult = index.setSettings(new JSONObject("{\"attributesForFaceting\": [\"brand\", \"category\"]}"), /* forwardToReplicas: */ false, /* requestOptions: */ null);
         index.waitTask(setSettingsResult.getString("taskID"));
 
         // Empty query
@@ -209,7 +210,7 @@ public class IndexTest extends RobolectricTestCase {
         objects.add(new JSONObject("{\"name\": \"Platinum Phone Cover\", \"brand\": \"Samsung\", \"category\": \"accessory\",\"stars\":2}"));
         objects.add(new JSONObject("{\"name\": \"Lame Phone\", \"brand\": \"Whatever\", \"category\": \"device\",\"stars\":1}"));
         objects.add(new JSONObject("{\"name\": \"Lame Phone cover\", \"brand\": \"Whatever\", \"category\": \"accessory\",\"stars\":1}"));
-        JSONObject task = index.addObjects(new JSONArray(objects));
+        JSONObject task = index.addObjects(new JSONArray(objects), /* requestOptions: */ null);
         index.waitTask(task.getString("taskID"));
 
         final Query query = new Query("phone").setFacets("brand", "category", "stars");
@@ -239,7 +240,7 @@ public class IndexTest extends RobolectricTestCase {
     @Test
     public void disjunctiveFacetingAsync2() throws Exception {
         // Set index settings.
-        JSONObject setSettingsResult = index.setSettings(new JSONObject("{\"attributesForFaceting\":[\"city\", \"stars\", \"facilities\"]}"));
+        JSONObject setSettingsResult = index.setSettings(new JSONObject("{\"attributesForFaceting\":[\"city\", \"stars\", \"facilities\"]}"), /* forwardToReplicas: */ false, /* requestOptions: */ null);
         index.waitTask(setSettingsResult.getString("taskID"));
 
         // Add objects.
@@ -248,7 +249,7 @@ public class IndexTest extends RobolectricTestCase {
                 .put(new JSONObject("{\"name\":\"Hotel B\", \"stars\":\"*\", \"facilities\":[\"wifi\"], \"city\":\"Paris\"}"))
                 .put(new JSONObject("{\"name\":\"Hotel C\", \"stars\":\"**\", \"facilities\":[\"bath\"], \"city\":\"San Fancisco\"}"))
                 .put(new JSONObject("{\"name\":\"Hotel D\", \"stars\":\"****\", \"facilities\":[\"spa\"], \"city\":\"Paris\"}"))
-                .put(new JSONObject("{\"name\":\"Hotel E\", \"stars\":\"****\", \"facilities\":[\"spa\"], \"city\":\"New York\"}")));
+                .put(new JSONObject("{\"name\":\"Hotel E\", \"stars\":\"****\", \"facilities\":[\"spa\"], \"city\":\"New York\"}")), /* requestOptions: */ null);
         index.waitTask(addObjectsResult.getString("taskID"));
 
         // Search.
@@ -572,7 +573,7 @@ public class IndexTest extends RobolectricTestCase {
         client.setReadTimeout(1000);
 
         Long start = System.currentTimeMillis();
-        assertNotNull("listIndexes() should return.", client.listIndexes());
+        assertNotNull("listIndexes() should return.", client.listIndexes(/* requestOptions: */ null));
         final long totalMillis = System.currentTimeMillis() - start;
         assertTrue(String.format("The test ran longer than expected (%d > %dms).", totalMillis, maxMillis), totalMillis <= maxMillis);
     }
@@ -604,7 +605,7 @@ public class IndexTest extends RobolectricTestCase {
         client.setReadTimeout(1000);
 
         Long start = System.currentTimeMillis();
-        assertNotNull("listIndexes() should return.", client.listIndexes());
+        assertNotNull("listIndexes() should return.", client.listIndexes(/* requestOptions: */ null));
         long end = System.currentTimeMillis() - start;
         assertTrue("The test ran longer than expected (" + end + "ms > 2s)", end < 2 * 1000);
     }
@@ -692,7 +693,7 @@ public class IndexTest extends RobolectricTestCase {
         }
 
         // Add objects.
-        JSONObject task = index.addObjects(new JSONArray(objects));
+        JSONObject task = index.addObjects(new JSONArray(objects), /* requestOptions: */ null);
         index.waitTask(task.getString("taskID"));
     }
 
@@ -838,16 +839,16 @@ public class IndexTest extends RobolectricTestCase {
         // Given a index, using a client that returns some json on search
         Client mockClient = mock(Client.class);
         Whitebox.setInternalState(index, "client", mockClient);
-        when(mockClient.postRequestRaw(anyString(), anyString(), anyBoolean())).thenReturn("{foo:42}".getBytes());
+        when(mockClient.postRequestRaw(anyString(), anyString(), anyBoolean(), isNull(RequestOptions.class))).thenReturn("{foo:42}".getBytes());
 
         // When searching twice separated by waitBetweenSeconds, fires nbTimes requests
         final Query query = new Query("San");
-        index.search(query);
+        index.search(query, /* requestOptions: */ null);
         if (waitBetweenSeconds > 0) {
             Thread.sleep(waitBetweenSeconds * 1000);
         }
-        index.search(query);
-        verify(mockClient, times(nbTimes)).postRequestRaw(anyString(), anyString(), anyBoolean());
+        index.search(query, /* requestOptions: */ null);
+        verify(mockClient, times(nbTimes)).postRequestRaw(anyString(), anyString(), anyBoolean(), isNull(RequestOptions.class));
     }
 
     @Test
@@ -900,9 +901,9 @@ public class IndexTest extends RobolectricTestCase {
     @Test
     public void getObjectAttributes() throws AlgoliaException {
         for (String id : ids) {
-            JSONObject object = index.getObject(id);
+            JSONObject object = index.getObject(id, /* requestOptions: */ null);
             assertEquals("The retrieved object should have 3 attributes.", 3, object.names().length()); // 2 attributes + `objectID`
-            object = index.getObject(id, Collections.singletonList("city"));
+            object = index.getObject(id, Collections.singletonList("city"), /* requestOptions: */ null);
             assertEquals("The retrieved object should have 2 attributes.", 2, object.names().length()); // 1 attribute + `objectID`
             assertNotNull("The retrieved object should have an `objectID` attribute.", object.optString("objectID", null));
             assertNotNull("The retrieved object should have a `city` attribute.", object.optString("city", null));
@@ -917,7 +918,7 @@ public class IndexTest extends RobolectricTestCase {
                 JSONObject object = results.getJSONObject(i);
                 assertEquals("The retrieved object should have 3 attributes.", 3, object.names().length()); // 2 attributes + `objectID`
             }
-            results = index.getObjects(ids, Collections.singletonList("city")).getJSONArray("results");
+            results = index.getObjects(ids, Collections.singletonList("city"), /* requestOptions: */ null).getJSONArray("results");
             for (int i = 0; i < results.length(); i++) {
                 JSONObject object = results.getJSONObject(i);
                 assertEquals("The retrieved object should have 2 attributes.", 2, object.names().length()); // 1 attribute + `objectID`
@@ -1104,7 +1105,9 @@ public class IndexTest extends RobolectricTestCase {
         final JSONObject setSettingsTask = index.setSettings(new JSONObject()
                 .put("attributesForFaceting", new JSONArray()
                         .put("searchable(series)")
-                        .put("kind"))
+                        .put("kind")),
+                /* forwardToReplicas: */ false,
+                /* requestOptions: */ null
         );
 
         final JSONObject addObjectsResult = index.addObjects(new JSONArray()
@@ -1137,7 +1140,8 @@ public class IndexTest extends RobolectricTestCase {
                         .put("name", "Calvin")
                         .put("kind", new JSONArray().put("human"))
                         .put("born", 1985)
-                        .put("series", "Calvin & Hobbes"))
+                        .put("series", "Calvin & Hobbes")),
+                /* requestOptions: */ null
         );
 
         index.waitTask(setSettingsTask.getString("taskID"));
@@ -1218,6 +1222,18 @@ public class IndexTest extends RobolectricTestCase {
         // Expect host to be up again after the delay has passed
         Thread.sleep(delay);
         assertTrue("A host that has failed should be considered up once the delay is over.", client.isUpOrCouldBeRetried(randomHostName));
+    }
+
+    @Test
+    public void requestOptions() throws Exception {
+        // Override the API key in the request options and check that we get an authentication error.
+        client.listIndexesAsync(new RequestOptions().setHeader("X-Algolia-API-Key", "ThisAPIKeyIsNotValid"), new AssertCompletionHandler() {
+            @Override
+            public void doRequestCompleted(JSONObject content, AlgoliaException error) {
+                assertNotNull(error);
+                assertEquals(403, error.getStatusCode());
+            }
+        });
     }
 
     private String getRandomString() {


### PR DESCRIPTION
This is an empty shell so far: it supports adding untyped headers, but that’s pretty much all. It will be leveraged as needed in the future.