### PR TITLE
feat(PlacesClient): GetByObjectID

### DIFF
--- a/algoliasearch/src/main/java/com/algolia/search/saas/places/PlacesClient.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/places/PlacesClient.java
@@ -127,4 +127,14 @@ public class PlacesClient extends AbstractClient {
             throw new RuntimeException(e); // should never happen
         }
     }
+
+    /**
+     * Get a place by its objectID.
+     * @param objectID the record's identifier.
+     * @return the corresponding record.
+     * @throws AlgoliaException when the given objectID does not exist.
+     */
+    public JSONObject getByObjectID(@NonNull String objectID) throws AlgoliaException {
+        return getRequest("/1/places/" + objectID, false);
+    }
 }

--- a/algoliasearch/src/test/java/com/algolia/search/saas/places/PlacesClientTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/places/PlacesClientTest.java
@@ -35,12 +35,14 @@ import org.junit.Test;
 import org.mockito.internal.util.reflection.Whitebox;
 import org.robolectric.util.concurrent.RoboExecutorService;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @SuppressLint("DefaultLocale")
 public class PlacesClientTest extends RobolectricTestCase {
+    public static final String OBJECT_ID_RUE_RIVOLI = "95057362_123324299";
     PlacesClient places;
 
     @Override
@@ -79,5 +81,17 @@ public class PlacesClientTest extends RobolectricTestCase {
                 assertTrue(content.optJSONArray("hits").length() > 0);
             }
         });
+    }
+
+    @Test
+    public void getByObjectIDValid() throws Exception {
+        final JSONObject rivoli = places.getByObjectID(OBJECT_ID_RUE_RIVOLI);
+        assertNotNull(rivoli);
+        assertEquals(OBJECT_ID_RUE_RIVOLI, rivoli.getString("objectID"));
+    }
+
+    @Test(expected = AlgoliaException.class)
+    public void getByObjectIDInvalid() throws Exception {
+        places.getByObjectID("4242424242");
     }
 }


### PR DESCRIPTION
Solves #389 (as #388 is blocked waiting, I'll handle the eventual merge conflict on `getRequest`'s usage). 