### PR TITLE
Fix waitTask overflow

### DIFF
--- a/algoliasearch/src/main/java/com/algolia/search/saas/Index.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/Index.java
@@ -1378,7 +1378,9 @@ public class Index {
                 } catch (InterruptedException e) {
                     continue;
                 }
-                timeToWait *= 2;
+
+                final long newTimeout = timeToWait * 2;
+                timeToWait = (newTimeout <= 0 || newTimeout >= MAX_TIME_MS_TO_WAIT) ? MAX_TIME_MS_TO_WAIT : newTimeout;
             }
         } catch (JSONException e) {
             throw new AlgoliaException(e.getMessage());


### PR DESCRIPTION
When waiting for a task, we multiply the waiting time *=2 . After the limit, the long will overflow to negative and so, Thread.sleep will throw an exception