### PR TITLE
Remove redundant public modifier on interface methods

### DIFF
--- a/algoliasearch/src/main/java/com/algolia/search/saas/CompletionHandler.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/CompletionHandler.java
@@ -39,5 +39,5 @@ public interface CompletionHandler {
      * @param content Content that was returned by the API (in case of success).
      * @param error Error that was encountered (in case of failure).
      */
-    public void requestCompleted(JSONObject content, AlgoliaException error);
+    void requestCompleted(JSONObject content, AlgoliaException error);
 }

--- a/algoliasearch/src/main/java/com/algolia/search/saas/Request.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/Request.java
@@ -61,19 +61,19 @@ public interface Request
      * case, cancelling never carries "undo" semantics.
      * </p>
      */
-    public void cancel();
+     void cancel();
 
     /**
      * Test if this request is still running.
      *
      * @return true if completed or cancelled, false if still running.
      */
-    public boolean isFinished();
+     boolean isFinished();
 
     /**
      * Test if this request has been cancelled.
      *
      * @return true if cancelled, false otherwise.
      */
-    public boolean isCancelled();
+     boolean isCancelled();
 }

--- a/algoliasearch/src/main/java/com/algolia/search/saas/helpers/BrowseIterator.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/helpers/BrowseIterator.java
@@ -56,7 +56,7 @@ public class BrowseIterator {
          * @param result   The results (in case of success).
          * @param error    The error (in case of error).
          */
-        public void handleBatch(@NonNull BrowseIterator iterator, JSONObject result, AlgoliaException error);
+        void handleBatch(@NonNull BrowseIterator iterator, JSONObject result, AlgoliaException error);
     }
 
     /** The index being browsed. */

--- a/algoliasearch/src/offline/java/com/algolia/search/saas/SyncListener.java
+++ b/algoliasearch/src/offline/java/com/algolia/search/saas/SyncListener.java
@@ -35,7 +35,7 @@ public interface SyncListener
      * Synchronization has just started.
      * @param index The synchronizing index.
      */
-    public void syncDidStart(MirroredIndex index);
+    void syncDidStart(MirroredIndex index);
 
     /**
      * Synchronization has just finished.
@@ -43,5 +43,5 @@ public interface SyncListener
      * @param error Null if success, otherwise indicates the error.
      * @param stats Statistics about the sync.
      */
-    public void syncDidFinish(MirroredIndex index, Throwable error, MirroredIndex.SyncStats stats);
+    void syncDidFinish(MirroredIndex index, Throwable error, MirroredIndex.SyncStats stats);
 }


### PR DESCRIPTION
Hello,

I was reading the code base and realized that some interface methods were unnecessarily marked public.

Cheers.