### PR TITLE
fix(Query): Accept any CharSequence

### DIFF
--- a/algoliasearch/src/main/java/com/algolia/search/saas/Query.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/Query.java
@@ -235,7 +235,7 @@ public class Query extends AbstractQuery {
      *
      * @param query Query text.
      */
-    public Query(String query) {
+    public Query(CharSequence query) {
         setQuery(query);
     }
 
@@ -1175,7 +1175,7 @@ public class Query extends AbstractQuery {
     /**
      * Set the full text query
      */
-    public @NonNull Query setQuery(String query) {
+    public @NonNull Query setQuery(CharSequence query) {
         return set(KEY_QUERY, query);
     }
 

--- a/algoliasearch/src/main/java/com/algolia/search/saas/places/PlacesQuery.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/places/PlacesQuery.java
@@ -50,7 +50,7 @@ public class PlacesQuery extends AbstractQuery {
      *
      * @param query Full text query.
      */
-    public PlacesQuery(String query) {
+    public PlacesQuery(CharSequence query) {
         setQuery(query);
     }
 
@@ -73,7 +73,7 @@ public class PlacesQuery extends AbstractQuery {
      * Set the full text query.
      */
     public @NonNull
-    PlacesQuery setQuery(String query) {
+    PlacesQuery setQuery(CharSequence query) {
         return set(KEY_QUERY, query);
     }
 


### PR DESCRIPTION
Don't require to wrap a `CharSequence` with a `String` to `setQuery`.