### PR TITLE
refactor(Query): Unify Boolean attributes' handling and testing

### DIFF
--- a/algoliasearch/src/main/java/com/algolia/search/saas/Query.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/Query.java
@@ -820,7 +820,7 @@ public class Query extends AbstractQuery {
      * car/cars will be considered as equals). Defaults to false.
      */
     public @NonNull
-    Query setIgnorePlurals(boolean enabled) {
+    Query setIgnorePlurals(Boolean enabled) {
         return set(KEY_IGNORE_PLURALS, enabled);
     }
 
@@ -1277,7 +1277,7 @@ public class Query extends AbstractQuery {
      *                Algolia dashboard. When `false`, the search query is excluded from percentile computation.
      */
     public @NonNull
-    Query setPercentileComputation(boolean enabled) {
+    Query setPercentileComputation(Boolean enabled) {
         return set(KEY_PERCENTILE_COMPUTATION, enabled);
     }
 
@@ -1389,7 +1389,7 @@ public class Query extends AbstractQuery {
      *                 only array items that matched at least partially are highlighted/snippeted.
      */
     public @NonNull
-    Query setRestrictHighlightAndSnippetArrays(boolean restrict) {
+    Query setRestrictHighlightAndSnippetArrays(Boolean restrict) {
         return set(KEY_RESTRICT_HIGHLIGHT_AND_SNIPPET, restrict);
     }
 

--- a/algoliasearch/src/main/java/com/algolia/search/saas/Query.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/Query.java
@@ -289,11 +289,12 @@ public class Query extends AbstractQuery {
      * search but not engine.
      */
     public @NonNull
-    Query setAdvancedSyntax(Boolean enabled) {
+    Query setAdvancedSyntax(@Nullable Boolean enabled) {
         return set(KEY_ADVANCED_SYNTAX, enabled);
     }
 
-    public Boolean getAdvancedSyntax() {
+    public @Nullable
+    Boolean getAdvancedSyntax() {
         return parseBoolean(get(KEY_ADVANCED_SYNTAX));
     }
 
@@ -304,11 +305,12 @@ public class Query extends AbstractQuery {
      *                Defaults to true.
      */
     public @NonNull
-    Query setAllowTyposOnNumericTokens(Boolean enabled) {
+    Query setAllowTyposOnNumericTokens(@Nullable Boolean enabled) {
         return set(KEY_ALLOW_TYPOS_ON_NUMERIC_TOKENS, enabled);
     }
 
-    public Boolean getAllowTyposOnNumericTokens() {
+    public @Nullable
+    Boolean getAllowTyposOnNumericTokens() {
         return parseBoolean(get(KEY_ALLOW_TYPOS_ON_NUMERIC_TOKENS));
     }
 
@@ -318,11 +320,12 @@ public class Query extends AbstractQuery {
      * @param enabled If set to true, the results will return queryID which is needed for sending click | conversion events. Defaults to false.
      */
     public @NonNull
-    Query setClickAnalytics(Boolean enabled) {
+    Query setClickAnalytics(@Nullable Boolean enabled) {
         return set(KEY_CLICK_ANALYTICS, enabled);
     }
 
-    public Boolean getClickAnalytics() {
+    public @Nullable
+    Boolean getClickAnalytics() {
         return parseBoolean(get(KEY_CLICK_ANALYTICS));
     }
 
@@ -333,11 +336,12 @@ public class Query extends AbstractQuery {
      *                analytics feature. Defaults to true.
      */
     public @NonNull
-    Query setAnalytics(Boolean enabled) {
+    Query setAnalytics(@Nullable Boolean enabled) {
         return set(KEY_ANALYTICS, enabled);
     }
 
-    public Boolean getAnalytics() {
+    public @Nullable
+    Boolean getAnalytics() {
         return parseBoolean(get(KEY_ANALYTICS));
     }
 
@@ -381,11 +385,12 @@ public class Query extends AbstractQuery {
      * geolocation)
      */
     public @NonNull
-    Query setAroundLatLngViaIP(Boolean enabled) {
+    Query setAroundLatLngViaIP(@Nullable Boolean enabled) {
         return set(KEY_AROUND_LAT_LNG_VIA_IP, enabled);
     }
 
-    public Boolean getAroundLatLngViaIP() {
+    public @Nullable
+    Boolean getAroundLatLngViaIP() {
         return parseBoolean(get(KEY_AROUND_LAT_LNG_VIA_IP));
     }
 
@@ -611,7 +616,7 @@ public class Query extends AbstractQuery {
      * @see <a href="https://www.algolia.com/doc/api-client/android/parameters/#facetingafterdistinct">facetingAfterDistinct's documentation</a>
      */
     public @NonNull
-    Query setFacetingAfterDistinct(Boolean enabled) {
+    Query setFacetingAfterDistinct(@Nullable Boolean enabled) {
         return set(KEY_FACETING_AFTER_DISTINCT, enabled);
     }
 
@@ -648,11 +653,11 @@ public class Query extends AbstractQuery {
      * attribute.
      */
     public @NonNull
-    Query setGetRankingInfo(Boolean enabled) {
+    Query setGetRankingInfo(@Nullable Boolean enabled) {
         return set(KEY_GET_RANKING_INFO, enabled);
     }
 
-    public Boolean getGetRankingInfo() {
+    public @Nullable Boolean getGetRankingInfo() {
         return parseBoolean(get(KEY_GET_RANKING_INFO));
     }
 
@@ -820,7 +825,7 @@ public class Query extends AbstractQuery {
      * car/cars will be considered as equals). Defaults to false.
      */
     public @NonNull
-    Query setIgnorePlurals(Boolean enabled) {
+    Query setIgnorePlurals(@Nullable Boolean enabled) {
         return set(KEY_IGNORE_PLURALS, enabled);
     }
 
@@ -1277,11 +1282,11 @@ public class Query extends AbstractQuery {
      *                Algolia dashboard. When `false`, the search query is excluded from percentile computation.
      */
     public @NonNull
-    Query setPercentileComputation(Boolean enabled) {
+    Query setPercentileComputation(@Nullable Boolean enabled) {
         return set(KEY_PERCENTILE_COMPUTATION, enabled);
     }
 
-    public Boolean getPercentileComputation() {
+    public @Nullable Boolean getPercentileComputation() {
         return parseBoolean(get(KEY_PERCENTILE_COMPUTATION));
     }
 
@@ -1372,11 +1377,12 @@ public class Query extends AbstractQuery {
      *                to true.
      */
     public @NonNull
-    Query setReplaceSynonymsInHighlight(Boolean enabled) {
+    Query setReplaceSynonymsInHighlight(@Nullable Boolean enabled) {
         return set(KEY_REPLACE_SYNONYMS_IN_HIGHLIGHT, enabled);
     }
 
-    public Boolean getReplaceSynonymsInHighlight() {
+    public @Nullable
+    Boolean getReplaceSynonymsInHighlight() {
         return parseBoolean(get(KEY_REPLACE_SYNONYMS_IN_HIGHLIGHT));
     }
 
@@ -1389,11 +1395,12 @@ public class Query extends AbstractQuery {
      *                 only array items that matched at least partially are highlighted/snippeted.
      */
     public @NonNull
-    Query setRestrictHighlightAndSnippetArrays(Boolean restrict) {
+    Query setRestrictHighlightAndSnippetArrays(@Nullable Boolean restrict) {
         return set(KEY_RESTRICT_HIGHLIGHT_AND_SNIPPET, restrict);
     }
 
-    public Boolean getRestrictHighlightAndSnippetArrays() {
+    public @Nullable
+    Boolean getRestrictHighlightAndSnippetArrays() {
         return parseBoolean(get(KEY_RESTRICT_HIGHLIGHT_AND_SNIPPET));
     }
 
@@ -1476,11 +1483,12 @@ public class Query extends AbstractQuery {
      * @param enabled False means that the total score of a record is the maximum score of an individual filter. Setting it to true changes the total score by adding together the scores of each filter found. Defaults to false.
      */
     public @NonNull
-    Query setSumOrFiltersScores(Boolean enabled) {
+    Query setSumOrFiltersScores(@Nullable Boolean enabled) {
         return set(KEY_SUM_OR_FILTERS_SCORES, enabled);
     }
 
-    public Boolean getSumOrFiltersScores() {
+    public @Nullable
+    Boolean getSumOrFiltersScores() {
         return parseBoolean(get(KEY_SUM_OR_FILTERS_SCORES));
     }
 
@@ -1491,11 +1499,12 @@ public class Query extends AbstractQuery {
      *                configuration. Defaults to true.
      */
     public @NonNull
-    Query setSynonyms(Boolean enabled) {
+    Query setSynonyms(@Nullable Boolean enabled) {
         return set(KEY_SYNONYMS, enabled);
     }
 
-    public Boolean getSynonyms() {
+    public @Nullable
+    Boolean getSynonyms() {
         return parseBoolean(get(KEY_SYNONYMS));
     }
 
@@ -1554,11 +1563,12 @@ public class Query extends AbstractQuery {
      *                Defaults to true.
      */
     public @NonNull
-    Query setEnableRules(Boolean enabled) {
+    Query setEnableRules(@Nullable Boolean enabled) {
         return set(KEY_ENABLE_RULES, enabled);
     }
 
-    public Boolean getEnableRules() {
+    public @Nullable
+    Boolean getEnableRules() {
         return parseBoolean(get(KEY_ENABLE_RULES));
     }
 

--- a/algoliasearch/src/main/java/com/algolia/search/saas/places/PlacesQuery.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/places/PlacesQuery.java
@@ -115,7 +115,7 @@ public class PlacesQuery extends AbstractQuery {
         return set(KEY_AROUND_LAT_LNG_VIA_IP, enabled);
     }
 
-    public Boolean getAroundLatLngViaIP() {
+    public @Nullable Boolean getAroundLatLngViaIP() {
         return parseBoolean(get(KEY_AROUND_LAT_LNG_VIA_IP));
     }
 

--- a/algoliasearch/src/test/java/com/algolia/search/saas/QueryTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/QueryTest.java
@@ -175,6 +175,11 @@ public class QueryTest extends RobolectricTestCase {
         assertEquals("A false boolean should should be in ignorePlurals.", "false", query.get("ignorePlurals"));
         assertEquals("A false boolean should be built and parsed successfully.", query.getIgnorePlurals(), Query.parse(query.build()).getIgnorePlurals());
 
+        query.setIgnorePlurals((Boolean) null);
+        assertEquals("A null boolean should disable ignorePlurals.", Boolean.FALSE, query.getIgnorePlurals().enabled);
+        assertEquals("A null boolean should be in ignorePlurals.", null, query.get("ignorePlurals"));
+        assertEquals("A null boolean should be built and parsed successfully.", query.getIgnorePlurals(), Query.parse(query.build()).getIgnorePlurals());
+
         // List values
         query.setIgnorePlurals((List<String>) null);
         assertFalse("A null list value should disable ignorePlurals.", query.getIgnorePlurals().enabled);

--- a/algoliasearch/src/test/java/com/algolia/search/saas/QueryTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/QueryTest.java
@@ -45,10 +45,7 @@ import static org.junit.Assert.fail;
  * Unit tests for the `Query` class.
  */
 public class QueryTest extends RobolectricTestCase {
-
-    // ----------------------------------------------------------------------
-    // Build & parse
-    // ----------------------------------------------------------------------
+    // region Build & parse
 
     /**
      * Test serializing a query into a URL query string.
@@ -92,10 +89,8 @@ public class QueryTest extends RobolectricTestCase {
         // Test parsing of escaped characters.
         assertEquals(query, Query.parse(queryString));
     }
-
-    // ----------------------------------------------------------------------
-    // Low-level
-    // ----------------------------------------------------------------------
+    // endregion
+    // region Low-level
 
     /**
      * Test low-level accessors.
@@ -115,9 +110,8 @@ public class QueryTest extends RobolectricTestCase {
         assertNull(query.get("b"));
     }
 
-    // ----------------------------------------------------------------------
-    // High-level
-    // ----------------------------------------------------------------------
+    // endregion
+    // region High-level
 
     @Test
     public void minWordSizefor1Typo() {

--- a/algoliasearch/src/test/java/com/algolia/search/saas/QueryTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/QueryTest.java
@@ -28,6 +28,8 @@ import org.json.JSONException;
 import org.junit.Test;
 
 import java.io.UnsupportedEncodingException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,10 +37,10 @@ import java.util.List;
 
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -112,7 +114,79 @@ public class QueryTest extends RobolectricTestCase {
 
     // endregion
     // region High-level
+    // region Boolean attributes
+    @Test
+    public void advancedSyntax() {
+        testBooleanAttribute("advancedSyntax");
+    }
 
+    @Test
+    public void aroundLatLngViaIP() {
+        testBooleanAttribute("aroundLatLngViaIP");
+    }
+
+    @Test
+    public void allowTyposOnNumericTokens() {
+        testBooleanAttribute("allowTyposOnNumericTokens");
+    }
+
+    @Test
+    public void analytics() {
+        testBooleanAttribute("analytics");
+    }
+
+    @Test
+    public void clickAnalytics() {
+        testBooleanAttribute("clickAnalytics");
+    }
+
+    @Test
+    public void enableRules() {
+        testBooleanAttribute("enableRules");
+    }
+
+    @Test
+    public void facetingAfterDistinct() {
+        testBooleanAttribute("facetingAfterDistinct");
+    }
+
+    @Test
+    public void getRankingInfo() {
+        testBooleanAttribute("getRankingInfo");
+    }
+
+    @Test
+    public void percentileComputation() {
+        testBooleanAttribute("percentileComputation");
+    }
+
+    @Test
+    public void replaceSynonymsInHighlight() {
+        testBooleanAttribute("replaceSynonymsInHighlight");
+    }
+
+    @Test
+    public void restrictHighlightAndSnippetArrays() {
+        testBooleanAttribute("restrictHighlightAndSnippetArrays");
+    }
+
+    @Test
+    public void sumOrFiltersScores() {
+        testBooleanAttribute("sumOrFiltersScores");
+    }
+
+    @Test
+    public void synonyms() {
+        testBooleanAttribute("synonyms");
+    }
+
+    // endregion
+    // region Integer attributes
+    // endregion
+    // region Typed attributes
+    // endregion
+    // region Uncategorized attributes
+    // TODO: Either categorise or restructure tests differently
     @Test
     public void minWordSizefor1Typo() {
         Query query = new Query();
@@ -141,21 +215,6 @@ public class QueryTest extends RobolectricTestCase {
         assertEquals(Integer.valueOf(999), query.getMinProximity());
         assertEquals("999", query.get("minProximity"));
         assertEquals(query.getMinProximity(), Query.parse(query.build()).getMinProximity());
-    }
-
-    @Test
-    public void getRankingInfo() {
-        Query query = new Query();
-        assertNull(query.getGetRankingInfo());
-        query.setGetRankingInfo(true);
-        assertEquals(Boolean.TRUE, query.getGetRankingInfo());
-        assertEquals("true", query.get("getRankingInfo"));
-        assertEquals(query.getGetRankingInfo(), Query.parse(query.build()).getGetRankingInfo());
-
-        query.setGetRankingInfo(false);
-        assertEquals(Boolean.FALSE, query.getGetRankingInfo());
-        assertEquals("false", query.get("getRankingInfo"));
-        assertEquals(query.getGetRankingInfo(), Query.parse(query.build()).getGetRankingInfo());
     }
 
     @Test
@@ -241,16 +300,6 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void percentileCalculation() {
-        Query query = new Query();
-        assertNull(query.getPercentileComputation());
-        query.setPercentileComputation(true);
-        assertEquals(Boolean.TRUE, query.getPercentileComputation());
-        assertEquals("true", query.get("percentileComputation"));
-        assertEquals(query.getPercentileComputation(), Query.parse(query.build()).getPercentileComputation());
-    }
-
-    @Test
     public void hitsPerPage() {
         Query query = new Query();
         assertNull(query.getHitsPerPage());
@@ -259,42 +308,6 @@ public class QueryTest extends RobolectricTestCase {
         assertEquals("50", query.get("hitsPerPage"));
         assertEquals(query.getHitsPerPage(), Query.parse(query.build()).getHitsPerPage());
     }
-
-    @Test
-    public void allowTyposOnNumericTokens() {
-        Query query = new Query();
-        assertNull(query.getAllowTyposOnNumericTokens());
-        query.setAllowTyposOnNumericTokens(true);
-        assertEquals(Boolean.TRUE, query.getAllowTyposOnNumericTokens());
-        assertEquals("true", query.get("allowTyposOnNumericTokens"));
-        assertEquals(query.getAllowTyposOnNumericTokens(), Query.parse(query.build()).getAllowTyposOnNumericTokens());
-
-        query.setAllowTyposOnNumericTokens(false);
-        assertEquals(Boolean.FALSE, query.getAllowTyposOnNumericTokens());
-        assertEquals("false", query.get("allowTyposOnNumericTokens"));
-        assertEquals(query.getAllowTyposOnNumericTokens(), Query.parse(query.build()).getAllowTyposOnNumericTokens());
-    }
-
-    @Test
-    public void analytics() {
-        Query query = new Query();
-        assertNull(query.getAnalytics());
-        query.setAnalytics(true);
-        assertEquals(Boolean.TRUE, query.getAnalytics());
-        assertEquals("true", query.get("analytics"));
-        assertEquals(query.getAnalytics(), Query.parse(query.build()).getAnalytics());
-    }
-
-    @Test
-    public void clickAnalytics() {
-        Query query = new Query();
-        assertNull(query.getClickAnalytics());
-        query.setClickAnalytics(true);
-        assertEquals(Boolean.TRUE, query.getClickAnalytics());
-        assertEquals("true", query.get("clickAnalytics"));
-        assertEquals(query.getClickAnalytics(), Query.parse(query.build()).getClickAnalytics());
-    }
-
 
     @Test
     public void sortFacetValuesBy() {
@@ -310,25 +323,6 @@ public class QueryTest extends RobolectricTestCase {
         assertEquals(query.getSortFacetValuesBy(), query2.getSortFacetValuesBy());
     }
 
-    @Test
-    public void synonyms() {
-        Query query = new Query();
-        assertNull(query.getSynonyms());
-        query.setSynonyms(true);
-        assertEquals(Boolean.TRUE, query.getSynonyms());
-        assertEquals("true", query.get("synonyms"));
-        assertEquals(query.getSynonyms(), Query.parse(query.build()).getSynonyms());
-    }
-
-    @Test
-    public void sumOrFiltersScores() {
-        Query query = new Query();
-        assertNull(query.getSumOrFiltersScores());
-        query.setSumOrFiltersScores(true);
-        assertEquals(Boolean.TRUE, query.getSumOrFiltersScores());
-        assertEquals("true", query.get("sumOrFiltersScores"));
-        assertEquals(query.getSumOrFiltersScores(), Query.parse(query.build()).getSumOrFiltersScores());
-    }
 
     @Test
     public void attributesToHighlight() {
@@ -511,26 +505,6 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void replaceSynonymsInHighlight() {
-        Query query = new Query();
-        assertNull(query.getReplaceSynonymsInHighlight());
-        query.setReplaceSynonymsInHighlight(true);
-        assertEquals(true, query.getReplaceSynonymsInHighlight());
-        assertEquals("true", query.get("replaceSynonymsInHighlight"));
-        assertEquals(query.getReplaceSynonymsInHighlight(), Query.parse(query.build()).getReplaceSynonymsInHighlight());
-    }
-
-    @Test
-    public void restrictHighlightAndSnippetArrays() {
-        Query query = new Query();
-        assertNull(query.getRestrictHighlightAndSnippetArrays());
-        query.setRestrictHighlightAndSnippetArrays(true);
-        assertEquals(true, query.getRestrictHighlightAndSnippetArrays());
-        assertEquals("true", query.get("restrictHighlightAndSnippetArrays"));
-        assertEquals(query.getRestrictHighlightAndSnippetArrays(), Query.parse(query.build()).getRestrictHighlightAndSnippetArrays());
-    }
-
-    @Test
     public void restrictSearchableAttributes() {
         Query query = new Query();
         assertNull(query.getRestrictSearchableAttributes());
@@ -627,16 +601,6 @@ public class QueryTest extends RobolectricTestCase {
     }
 
     @Test
-    public void aroundLatLngViaIP() {
-        Query query = new Query();
-        assertNull(query.getAroundLatLngViaIP());
-        query.setAroundLatLngViaIP(true);
-        assertEquals(Boolean.TRUE, query.getAroundLatLngViaIP());
-        assertEquals("true", query.get("aroundLatLngViaIP"));
-        assertEquals(query.getAroundLatLngViaIP(), Query.parse(query.build()).getAroundLatLngViaIP());
-    }
-
-    @Test
     public void aroundLatLng() {
         Query query = new Query();
         assertNull(query.getAroundLatLng());
@@ -703,16 +667,6 @@ public class QueryTest extends RobolectricTestCase {
         assertEquals(VALUE, query.getFacetFilters());
         assertEquals("[[\"category:Book\",\"category:Movie\"],\"author:John Doe\"]", query.get("facetFilters"));
         assertEquals(query.getFacetFilters(), Query.parse(query.build()).getFacetFilters());
-    }
-
-    @Test
-    public void advancedSyntax() {
-        Query query = new Query();
-        assertNull(query.getAdvancedSyntax());
-        query.setAdvancedSyntax(true);
-        assertEquals(Boolean.TRUE, query.getAdvancedSyntax());
-        assertEquals("true", query.get("advancedSyntax"));
-        assertEquals(query.getAdvancedSyntax(), Query.parse(query.build()).getAdvancedSyntax());
     }
 
     @Test
@@ -899,24 +853,51 @@ public class QueryTest extends RobolectricTestCase {
         assertArrayEquals(query.getRuleContexts(), Query.parse(query.build()).getRuleContexts());
     }
 
-    @Test
-    public void enableRules() {
+    // endregion
+    // endregion
+    //region Test Helpers
+    public void testBooleanAttribute(String name) {
+        // Get getter and setter
+        final String nameUpper = name.substring(0, 1).toUpperCase() + name.substring(1);
         Query query = new Query();
-        assertNull(query.getEnableRules());
-        query.setEnableRules(true);
-        assertEquals(Boolean.TRUE, query.getEnableRules());
-        assertEquals("true", query.get("enableRules"));
-        assertEquals(query.getEnableRules(), Query.parse(query.build()).getEnableRules());
-    }
+        Method getter = null;
+        Method setter = null;
+        try {
+            getter = query.getClass().getMethod("get" + nameUpper);
+        } catch (NoSuchMethodException e) {
+            fail("Missing getter: " + e.getLocalizedMessage());
+        }
+        try {
+            setter = query.getClass().getMethod("set" + nameUpper, Boolean.class);
+        } catch (NoSuchMethodException e) {
+            fail("Missing setter: " + e.getLocalizedMessage());
+        }
 
+        try {
+            // Default value
+            assertNull("By default, " + name + " should be null.", getter.invoke(query));
 
-    @Test
-    public void facetingAfterDistinct() {
-        Query query = new Query();
-        assertNull(query.getFacetingAfterDistinct());
-        query.setFacetingAfterDistinct(true);
-        assertEquals(Boolean.TRUE, query.getFacetingAfterDistinct());
-        assertEquals("true", query.get("facetingAfterDistinct"));
-        assertEquals(query.getFacetingAfterDistinct(), Query.parse(query.build()).getFacetingAfterDistinct());
+            // Boolean values
+            setter.invoke(query, true);
+            assertEquals("A true boolean should enable " + name, Boolean.TRUE, getter.invoke(query));
+            assertEquals("A true boolean should be in " + name, "true", query.get(name));
+            assertEquals("A true boolean should be built and parsed correctly", getter.invoke(query), getter.invoke(Query.parse(query.build())));
+
+            setter.invoke(query, false);
+            assertEquals("A false boolean should enable " + name, Boolean.FALSE, getter.invoke(query));
+            assertEquals("A false boolean should be in " + name, "false", query.get(name));
+            assertEquals("A false boolean should be built and parsed correctly", getter.invoke(query), getter.invoke(Query.parse(query.build())));
+
+            setter.invoke(query, (Boolean) null);
+            assertEquals("A null boolean should disable " + name, null, getter.invoke(query));
+            assertEquals("A null boolean should be in " + name, null, query.get(name));
+            assertEquals("A null boolean should be built and parsed correctly", getter.invoke(query), getter.invoke(Query.parse(query.build())));
+        } catch (IllegalAccessException e) {
+            fail(e.getLocalizedMessage());
+            e.printStackTrace();
+        } catch (InvocationTargetException e) {
+            fail(e.getLocalizedMessage());
+        }
     }
+    //endregion
 }


### PR DESCRIPTION
## Boolean attributes handling

Although we first thought it would consist in `Move Boolean to boolean in the client`, exploration showed that we need to stick to `Boolean` instead: 

- Query's boolean attributes can either be _unset_, _true_ or _false_
- The default for each attribute is _not something we can rely on in the library_ (although sometimes it's mentioned in the docstring)
Consequently, we need our boolean getters to return either of three values: `Boolean.TRUE`, `Boolean.FALSE`, and `null` if unset. 

This means **getters should be implemented as `public @Nullable Boolean getXXX()`**.

Likewise, the user should be able to unset an attribute's value, putting the `Query` in its default state for that attribute.

This means **setters should be implemented as `public @NonNull Query setXXX(@Nullable Boolean xxx);`**.

This is implemented in 530c577, which refactors setters that were not compliant with this reasoning; and 68a955c, which adds appropriate annotations.

## Boolean attributes testing

Testing of our boolean attributes was inconsistent, sometimes testing `TRUE` and `FALSE` cases and sometimes only one of them. Adding a test for the `null` case was an opportunity to refactor those.

I went the following way:

- Extract the Boolean testing logic into [`testBooleanAttribute`](https://github.com/algolia/algoliasearch-client-android/blob/39a4dee0c71eac1db2f8a4a6a53905f1713e9a73/algoliasearch/src/test/java/com/algolia/search/saas/QueryTest.java#L874-L916), a generic method testing all cases of Boolean values for a given attribute
- Refactor Boolean tests to always use `testBooleanAttribute`. This makes the tests much more concise, more consistent, without any significant performance drawback (runnning 5 times `QueryTest` before and after this change results in a mean difference of `0.12`s).
- Reorganize tests into [regions for attribute types](https://github.com/algolia/algoliasearch-client-android/blob/39a4dee0c71eac1db2f8a4a6a53905f1713e9a73/algoliasearch/src/test/java/com/algolia/search/saas/QueryTest.java#L116). If we like the benefits of this new structure, I would apply it to each other attribute type.
- For mixed type attributes that can be Boolean (currently `ignorePlurals`), add assertions for the `null` case and keep it unchanged until further refactoring.