### PR TITLE
[refact][stale] Make the `User-Agent` header a static property

### DIFF
--- a/algoliasearch/src/main/java/com/algolia/search/saas/AbstractClient.java
+++ b/algoliasearch/src/main/java/com/algolia/search/saas/AbstractClient.java
@@ -113,10 +113,14 @@ public abstract class AbstractClient {
      * The user agents as a raw string. This is what is passed in request headers.
      * WARNING: It is stored for efficiency purposes. It should not be modified directly.
      */
-    private String userAgentRaw;
+    private static String userAgentRaw;
 
     /** The user agents, as a structured list of library versions. */
-    private List<LibraryVersion> userAgents = new ArrayList<>();
+    private static List<LibraryVersion> userAgents = new ArrayList<>();
+    static {
+        addUserAgent(new LibraryVersion("Algolia for Android", version));
+        addUserAgent(new LibraryVersion("Android", Build.VERSION.RELEASE));
+    }
 
     /** Connect timeout (ms). */
     private int connectTimeout = 2000;
@@ -164,8 +168,6 @@ public abstract class AbstractClient {
     protected AbstractClient(@Nullable String applicationID, @Nullable String apiKey, @Nullable String[] readHosts, @Nullable String[] writeHosts) {
         this.applicationID = applicationID;
         this.apiKey = apiKey;
-        this.addUserAgent(new LibraryVersion("Algolia for Android", version));
-        this.addUserAgent(new LibraryVersion("Android", Build.VERSION.RELEASE));
         if (readHosts != null)
             setReadHosts(readHosts);
         if (writeHosts != null)
@@ -316,17 +318,21 @@ public abstract class AbstractClient {
      *
      * @param userAgent The library to add.
      */
-    public void addUserAgent(@NonNull LibraryVersion userAgent) {
-        userAgents.add(userAgent);
-        updateUserAgents();
+    public static void addUserAgent(@NonNull LibraryVersion userAgent) {
+        if (!userAgents.contains(userAgent)) {
+            userAgents.add(userAgent);
+            updateUserAgents();
+        }
     }
 
     /**
      * Remove a software library from the list of user agents.
      *
+     * @deprecated Will be removed in a future release.
+     *
      * @param userAgent The library to remove.
      */
-    public void removeUserAgent(@NonNull LibraryVersion userAgent) {
+    public static void removeUserAgent(@NonNull LibraryVersion userAgent) {
         userAgents.remove(userAgent);
         updateUserAgents();
     }
@@ -336,7 +342,7 @@ public abstract class AbstractClient {
      *
      * @return The declared user agents.
      */
-    public @NonNull LibraryVersion[] getUserAgents() {
+    public static @NonNull LibraryVersion[] getUserAgents() {
         return userAgents.toArray(new LibraryVersion[userAgents.size()]);
     }
 
@@ -346,11 +352,11 @@ public abstract class AbstractClient {
      * @param userAgent The user agent to look for.
      * @return true if it is declared on this client, false otherwise.
      */
-    public boolean hasUserAgent(@NonNull LibraryVersion userAgent) {
+    public static boolean hasUserAgent(@NonNull LibraryVersion userAgent) {
         return userAgents.contains(userAgent);
     }
 
-    private void updateUserAgents() {
+    private static void updateUserAgents() {
         StringBuilder s = new StringBuilder();
         for (LibraryVersion userAgent : userAgents) {
             if (s.length() != 0) {

--- a/algoliasearch/src/offline/java/com/algolia/search/saas/OfflineClient.java
+++ b/algoliasearch/src/offline/java/com/algolia/search/saas/OfflineClient.java
@@ -72,6 +72,14 @@ public class OfflineClient extends Client
     /** Background queue used to run transaction bodies (but not the build). */
     protected ExecutorService transactionExecutorService = Executors.newSingleThreadExecutor();
 
+    // ----------------------------------------------------------------------
+    // Initialization
+    // ----------------------------------------------------------------------
+
+    static {
+        addUserAgent(new LibraryVersion("algoliasearch-offline-core-android", Sdk.getInstance().getVersionString()));
+    }
+
     /**
      * Construct a new offline-enabled API client.
      *
@@ -117,7 +125,6 @@ public class OfflineClient extends Client
         } else {
             this.rootDataDir = getDefaultDataDir();
         }
-        this.addUserAgent(new LibraryVersion("algoliasearch-offline-core-android", Sdk.getInstance().getVersionString()));
     }
 
     /**

--- a/algoliasearch/src/test/java/com/algolia/search/saas/ClientTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/ClientTest.java
@@ -33,6 +33,8 @@ import java.lang.ref.WeakReference;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * <a href="http://d.android.com/tools/testing/testing_android.html">Testing Fundamentals</a>
@@ -77,5 +79,24 @@ public class ClientTest extends RobolectricTestCase {
         System.gc();
         assertNull(indices.get(indexName).get());
         */
+    }
+
+    @Test
+    public void userAgent() throws Exception {
+        // Test the default value.
+        String userAgent = (String) Whitebox.getInternalState(client, "userAgentRaw"); // works even for static field
+        assertTrue(userAgent.matches("^Algolia for Android \\([0-9.]+\\); Android \\(([0-9.]+(_r[0-9]+)?|unknown)\\)$"));
+
+        // Manipulate the list.
+        assertFalse(AbstractClient.hasUserAgent(new Client.LibraryVersion("toto", "6.6.6")));
+        AbstractClient.addUserAgent(new Client.LibraryVersion("toto", "6.6.6"));
+        assertTrue(AbstractClient.hasUserAgent(new Client.LibraryVersion("toto", "6.6.6")));
+        userAgent = (String) Whitebox.getInternalState(client, "userAgentRaw");
+        assertTrue(userAgent.matches("^.*; toto \\(6.6.6\\)$"));
+
+        // Check that adding the same user agent twice results in a no-op.
+        AbstractClient.addUserAgent(new Client.LibraryVersion("toto", "6.6.6"));
+        final String userAgent2 = (String) Whitebox.getInternalState(client, "userAgentRaw");
+        assertEquals(userAgent, userAgent2);
     }
 }

--- a/algoliasearch/src/test/java/com/algolia/search/saas/IndexTest.java
+++ b/algoliasearch/src/test/java/com/algolia/search/saas/IndexTest.java
@@ -862,20 +862,6 @@ public class IndexTest extends RobolectricTestCase {
     }
 
     @Test
-    public void userAgent() throws Exception {
-        // Test the default value.
-        String userAgent = (String) Whitebox.getInternalState(client, "userAgentRaw");
-        assertTrue(userAgent.matches("^Algolia for Android \\([0-9.]+\\); Android \\(([0-9.]+(_r[0-9]+)?|unknown)\\)$"));
-
-        // Manipulate the list.
-        assertFalse(client.hasUserAgent(new Client.LibraryVersion("toto", "6.6.6")));
-        client.addUserAgent(new Client.LibraryVersion("toto", "6.6.6"));
-        assertTrue(client.hasUserAgent(new Client.LibraryVersion("toto", "6.6.6")));
-        userAgent = (String) Whitebox.getInternalState(client, "userAgentRaw");
-        assertTrue(userAgent.matches("^.*; toto \\(6.6.6\\)$"));
-    }
-
-    @Test
     public void getObjectAttributes() throws AlgoliaException {
         for (String id : ids) {
             JSONObject object = index.getObject(id);

--- a/algoliasearch/src/testOffline/java/com/algolia/search/saas/OfflineClientTest.java
+++ b/algoliasearch/src/testOffline/java/com/algolia/search/saas/OfflineClientTest.java
@@ -26,6 +26,7 @@ package com.algolia.search.saas;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Test;
+import org.mockito.internal.util.reflection.Whitebox;
 
 import java.util.concurrent.CountDownLatch;
 
@@ -41,6 +42,13 @@ import static org.junit.Assert.assertTrue;
  * Unit tests for the `OfflineIndex` class.
  */
 public class OfflineClientTest extends OfflineTestBase  {
+    @Test
+    public void userAgent() throws Exception {
+        // Check that the Offline Core is properly registered in the `User-Agent` header.
+        final String userAgent = (String) Whitebox.getInternalState(client, "userAgentRaw");
+        assertTrue(userAgent.matches("^.*; algoliasearch-offline-core-android \\(([0-9.]+)\\)($|;)"));
+    }
+
     @Test
     public void testListIndexes() throws Exception {
         final CountDownLatch signal = new CountDownLatch(1);


### PR DESCRIPTION
While cleaning up stale branches on the client, I noticed the unmerged commit 71fde63:

> ### [refact] Make the `User-Agent` header a static property
> Why?
>
>1. It’s a property of the code, not really of the `Client` instance, so it’s better off static anyway.
>
>2. It will be required to decouple the `Searcher` class in InstantSearch from the `Index` class.

@clement-leprovost @robertmogos is this still relevant? If yes, let's merge it :muscle: 